### PR TITLE
Use of outdated API when building with OTP 21

### DIFF
--- a/include/dns_tests.hrl
+++ b/include/dns_tests.hrl
@@ -219,19 +219,19 @@ decode_encode_optdata_test_() ->
 
 decode_encode_optdata_owner_test_() ->
     application:start(crypto),
-    Cases = [ #dns_opt_owner{seq = crypto:rand_uniform(0, 255),
+    Cases = [ #dns_opt_owner{seq = rand:uniform(255),
 			     primary_mac = crypto:strong_rand_bytes(6),
 			     wakeup_mac = crypto:strong_rand_bytes(6),
 			     password = crypto:strong_rand_bytes(6)},
-	      #dns_opt_owner{seq = crypto:rand_uniform(0, 255),
+	      #dns_opt_owner{seq = rand:uniform(255),
 			     primary_mac = crypto:strong_rand_bytes(6),
 			     wakeup_mac = crypto:strong_rand_bytes(6),
 			     password = crypto:strong_rand_bytes(4)},
-	      #dns_opt_owner{seq = crypto:rand_uniform(0, 255),
+	      #dns_opt_owner{seq = rand:uniform(255),
 			     primary_mac = crypto:strong_rand_bytes(6),
 			     wakeup_mac = crypto:strong_rand_bytes(6),
 			     _ = <<>>},
-	      #dns_opt_owner{seq = crypto:rand_uniform(0, 255),
+	      #dns_opt_owner{seq = rand:uniform(255),
 			     primary_mac = crypto:strong_rand_bytes(6),
 			     _ = <<>>} ],
     [ ?_assertEqual([Case], decode_optrrdata(encode_optrrdata([Case])))

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -604,7 +604,7 @@ encode_message_pop_optrr(Other) -> {<<>>, Other}.
 
 %% @doc Returns a random integer suitable for use as DNS message identifier.
 -spec random_id() -> message_id().
-random_id() -> crypto:rand_uniform(0, 65535).
+random_id() -> rand:uniform(65535).
 
 %%%===================================================================
 %%% TSIG functions


### PR DESCRIPTION
When compiling with OTP 21 the following warning shows up:

"Warning: crypto:rand_uniform/2 is deprecated and will be removed in a future release; use rand:uniform/1"

This is to satisfy that warning.