### PR TITLE
Rebar config git dependency tuple

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
             {platform_define, "^[0-9]+", namespaced_types}
 ]}.
 {deps, [{base32, ".*",
-         {git, "https://github.com/dnsimple/base32_erlang.git", "master"}}
+         {git, "https://github.com/dnsimple/base32_erlang.git", {branch, "master"}}}
        ]}.
 {eunit_opts, [verbose]}.
 


### PR DESCRIPTION
When building against `dns_erlang`, we get a warning that the rebar config for a git dependency should prefer
`{branch, "master"}`
instead of 
`"master"`
to be more specific about whether this is a branch, a tag, etc.