### PR TITLE
crypto:sha/1 deprecated in factor of crypto:hash/2

### DIFF
--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -168,7 +168,7 @@ gen_nsec3(RRs, ZoneName, Alg, Salt, Iterations, TTL, Class, Opts) ->
 	 non_neg_integer()) -> binary().
 ih(H, Salt, X, 0) when is_function(H, 1) -> H([X, Salt]);
 ih(H, Salt, X, I) when is_function(H, 1) -> ih(H, Salt, H([X, Salt]), I - 1);
-ih(?DNSSEC_NSEC3_ALG_SHA1, Salt, X, I) -> ih(fun crypto:sha/1, Salt, X, I).
+ih(?DNSSEC_NSEC3_ALG_SHA1, Salt, X, I) -> ih(fun (Data) -> crypto:hash(sha, Data) end, Salt, X, I).
 
 add_next_hash([#dns_rr{data = #dns_rrdata_nsec3{hash = First}}|_] = Hashes) ->
     add_next_hash(Hashes, [], First).


### PR DESCRIPTION
closes #14 

At some point (I believe it was OTP20), `crypto:sha/1` was removed in favor of `crypto:hash/2`. This was causing a dnssec test to fail because we were relying on `crypto:sha/1` in the case of using `DNSSEC_NSEC3_ALG_SHA1` when creating the NSEC3 hash function.
