### PR TITLE
Support building with mix

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,16 @@
-{ok, Version} = application:get_key(rebar, vsn),
+{ok, Version} = case application:get_env(rebar, vsn) of
+                    {ok, VSN} ->
+                        VSN;
+                    undefined ->
+                        %% is mix used
+                        {ok, "3"}
+                        % case lists:keymember(mix, 1, application:loaded_applications()) of
+                        %     true ->
+                        %         {ok, "3"};
+                        %     _ ->
+                        %         undefined
+                        % end
+                end,
 Fun =
     fun
         ({erl_opts, ErlOpts})  ->


### PR DESCRIPTION
When building using mix, rebar version is not defined, causing an error with the script:

```
Error evaluating Rebar config script ./rebar.config.script:9: evaluation failed with reason error:{badmatch,undefined} and stacktrace [{erl_eval,expr,3,[]}]
Any dependencies defined in the script won't be available unless you add them to your Mix project
```

This change defaults to Rebar 3 in that case.