### PR TITLE
Escape backslashes too

### DIFF
--- a/test/dns_test.erl
+++ b/test/dns_test.erl
@@ -592,14 +592,16 @@ dname_to_labels_test_() ->
         {"a.b.c.", [<<"a">>, <<"b">>, <<"c">>]},
         {<<"a.b.c.">>, [<<"a">>, <<"b">>, <<"c">>]},
         {"a\\.b.c", [<<"a.b">>, <<"c">>]},
-        {<<"a\\.b.c">>, [<<"a.b">>, <<"c">>]}
+        {<<"a\\.b.c">>, [<<"a.b">>, <<"c">>]},
+        {<<"a\\\\.b.c">>, [<<"a\\">>, <<"b">>, <<"c">>]}
     ],
     [?_assertEqual(Expect, dns:dname_to_labels(Arg)) || {Arg, Expect} <- Cases].
 
 labels_to_dname_test_() ->
     Cases = [
         {[<<"a">>, <<"b">>, <<"c">>], <<"a.b.c">>},
-        {[<<"a.b">>, <<"c">>], <<"a\\.b.c">>}
+        {[<<"a.b">>, <<"c">>], <<"a\\.b.c">>},
+        {[<<"a\\">>, <<"b">>, <<"c">>], <<"a\\\\.b.c">>}
     ],
     [?_assertEqual(Expect, dns:labels_to_dname(Arg)) || {Arg, Expect} <- Cases].
 


### PR DESCRIPTION
When a packet is received with a query for `\\.test` (that is, a name with two labels, one composed of only a backslash character, and the label “test”), `labels_to_dname()` decodes it to "\\.test". Calling `dname_to_labels()` again on that result yields `\.test` (that is, a name with one label, “.test”) instead of `\\.test`.

The solution is to also backslash-escape the backslash character.