### PR TITLE
using non-deprecated Crypto API functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp_version: ['26.1', '25.3', '24.3']
+        otp_version: ['26.2', '25.3']
 
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp_version: ['26.1', '25.3', '24.3']
+        otp_version: ['26.2', '25.3']
 
     needs:
       - build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-erlang 24.1
+erlang 26.2.5.2

--- a/include/dnssec_tests.hrl
+++ b/include/dnssec_tests.hrl
@@ -218,8 +218,9 @@ test_sample_key(dsa, PrivKey, PubKey) ->
     crypto:verify(dss, sha, Sample, Sig, PubKey);
 test_sample_key(rsa, PrivKey, PubKey) ->
     Sample = <<"1234">>,
-    Cipher = crypto:private_encrypt(rsa, Sample, PrivKey, rsa_pkcs1_padding),
-    Sample =:= crypto:public_decrypt(rsa, Cipher, PubKey, rsa_pkcs1_padding).
+    Signature = crypto:sign(rsa, sha, Sample, PrivKey, [{rsa_padding, rsa_pkcs1_padding}]),
+    crypto:verify(rsa, sha, Sample, Signature, PubKey, [{rsa_padding, rsa_pkcs1_padding}]).
+
 
 dnskey_pubkey_gen_test_() ->
     [

--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -502,21 +502,24 @@ verify_rrsig(
                             Alg =:= ?DNS_ALG_RSASHA256 orelse
                             Alg =:= ?DNS_ALG_RSASHA512
                     ->
-                        SigPayload =
-                            try
-                                crypto:public_decrypt(
-                                    rsa, Sig, Key, rsa_pkcs1_padding
-                                )
-                            catch
-                                error:decrypt_failed -> undefined
-                            end,
-                        SigInput =:= SigPayload;
+                        try
+                            crypto:verify(
+                                rsa, dns_algo_to_digest_type(Alg), SigInput, Sig, Key, [{rsa_padding, rsa_pkcs1_padding}]
+                            )
+                        catch
+                            error:decrypt_failed -> undefined
+                        end;
                     (_) ->
                         false
                 end,
                 Keys
             )
     end.
+
+dns_algo_to_digest_type(?DNS_ALG_NSEC3RSASHA1) -> sha;
+dns_algo_to_digest_type(?DNS_ALG_RSASHA1) -> sha;
+dns_algo_to_digest_type(?DNS_ALG_RSASHA256) -> sha256;
+dns_algo_to_digest_type(?DNS_ALG_RSASHA512) -> sha512.
 
 build_sig_input(
     SignersName,

--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -425,12 +425,6 @@ sign_rrset(
                     Key,
                     [{rsa_padding, rsa_pkcs1_padding}]
                 )
-                % crypto:private_encrypt(
-                %     rsa,
-                %     BaseSigInput,
-                %     Key,
-                %     rsa_pkcs1_padding
-                % )
         end,
     Data = Data0#dns_rrdata_rrsig{signature = Signature},
     #dns_rr{
@@ -510,13 +504,9 @@ verify_rrsig(
                             Alg =:= ?DNS_ALG_RSASHA512
                     ->
                         try
-                            io:format("SigInput: ~p~n", [SigInput]),
-                            io:format("Sig: ~p~n", [Sig]),
-                            io:format("Data: ~p~n", [Data]),
                             SigPayload = crypto:public_decrypt(
                                 rsa, Sig, Key, rsa_pkcs1_padding
                             ),
-                            io:format("SigPayload: ~p~n", [SigPayload]),
                             crypto:verify(
                                 rsa, dns_algo_to_digest_type(Alg), SigInput, Sig, Key, [{rsa_padding, rsa_pkcs1_padding}]
                             )

--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -504,9 +504,6 @@ verify_rrsig(
                             Alg =:= ?DNS_ALG_RSASHA512
                     ->
                         try
-                            SigPayload = crypto:public_decrypt(
-                                rsa, Sig, Key, rsa_pkcs1_padding
-                            ),
                             crypto:verify(
                                 rsa, dns_algo_to_digest_type(Alg), SigInput, Sig, Key, [{rsa_padding, rsa_pkcs1_padding}]
                             )

--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -418,12 +418,19 @@ sign_rrset(
                     Alg =:= ?DNS_ALG_RSASHA256 orelse
                     Alg =:= ?DNS_ALG_RSASHA512
             ->
-                crypto:private_encrypt(
+                crypto:sign(
                     rsa,
+                    dns_algo_to_digest_type(Alg),
                     BaseSigInput,
                     Key,
-                    rsa_pkcs1_padding
+                    [{rsa_padding, rsa_pkcs1_padding}]
                 )
+                % crypto:private_encrypt(
+                %     rsa,
+                %     BaseSigInput,
+                %     Key,
+                %     rsa_pkcs1_padding
+                % )
         end,
     Data = Data0#dns_rrdata_rrsig{signature = Signature},
     #dns_rr{
@@ -503,6 +510,13 @@ verify_rrsig(
                             Alg =:= ?DNS_ALG_RSASHA512
                     ->
                         try
+                            io:format("SigInput: ~p~n", [SigInput]),
+                            io:format("Sig: ~p~n", [Sig]),
+                            io:format("Data: ~p~n", [Data]),
+                            SigPayload = crypto:public_decrypt(
+                                rsa, Sig, Key, rsa_pkcs1_padding
+                            ),
+                            io:format("SigPayload: ~p~n", [SigPayload]),
                             crypto:verify(
                                 rsa, dns_algo_to_digest_type(Alg), SigInput, Sig, Key, [{rsa_padding, rsa_pkcs1_padding}]
                             )


### PR DESCRIPTION
Refactoring calls to remove deprecated Crypto API calls.

Fixes https://github.com/dnsimple/dns_erlang/issues/38