### PR TITLE
Adds yamllint and markdownlint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+---
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -1,3 +1,5 @@
+---
+
 name: Check Dependencies
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
+---
+
 name: CI
 
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run YAML Lint
+        uses: actionshub/yamllint@main
+
+  markdownlint-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v3.4.0
+        with:
+          files: .
+          config_file: ".markdownlint.yaml"
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -47,6 +66,8 @@ jobs:
 
     needs:
       - build
+      - markdownlint-cli
+      - yamllint
 
     steps:
       - uses: actions/checkout@v4

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,13 @@
+---
+default: true
+
+# no-hard-tabs
+MD010:
+  code_blocks: false
+
+# no-multiple-blanks
+MD012:
+  maximum: 2
+
+# line-length
+MD013: false

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 256
+    level: warning
+  truthy:
+    ignore: |
+      /.github/workflows/*.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-#### 1. Clone the repository
+### 1. Clone the repository
 
 Clone the repository and move into it:
 
@@ -11,15 +11,15 @@ git clone git@github.com:dnsimple/dns_erlang.git
 cd dns_erlang
 ```
 
-#### 2. Install Erlang
+### 2. Install Erlang
 
-#### 3. Create your own working branch
+### 3. Create your own working branch
 
 ```shell
 git checkout -b dev_new_feature_xyz
 ```
 
-#### 3. Build and test
+### 3. Build and test
 
 Compile the project and [run the test suite](#testing) to check everything works as expected.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note that all support RR types must include a `dns_rrdata_` record definition, u
 
 The `dns` module is the primary entry point for the functionality in this library. The module exports various types used in type specs, such as `message()`, which indicates a `#dns_message` record, `query()` which represents a single `#dns_query` record, `questions()`, which represents a list of queries, etc.
 
-It also exports functions for encoding and decoding messages, TSIG supporting functions, and various utility functions for comparing domain names, converting domain names into different cases, converting to and from label lists, etc. 
+It also exports functions for encoding and decoding messages, TSIG supporting functions, and various utility functions for comparing domain names, converting domain names into different cases, converting to and from label lists, etc.
 
 ### dns\_record.erl
 


### PR DESCRIPTION
This PR adds YAML and Markdown linters config and make them run in the CI Github Action.

This is an effort on standardizing our Erlang repositories.

## :shipit: Deploy Steps

- [x] Just merge, no need to cut a release for this

## :shipit: Verification Steps

- [x] CI passing while executing YAML and Markdown linters
