### PR TITLE
Add a test to verify encoding and decoding of big TXT sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added xref, dialyzer, and ex_doc
 - Add strict typing and RFC references to all records
-- Add support for TXT splitting of strings over the maximum permitted size (#57)
+- Add support for TXT splitting of strings over the maximum permitted size
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+- Added xref, dialyzer, and ex_doc
+- Add strict typing and RFC references to all records
+- Add support for TXT splitting of strings over the maximum permitted size
+
 ## 2.0.0
 
 ### Changed

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -1304,7 +1304,7 @@ decode_rrdata(_Class, ?DNS_TYPE_CDS, <<KeyTag:16, Alg:8, DigestType:8, Digest/bi
         digest = Digest
     };
 decode_rrdata(_Class, ?DNS_TYPE_HINFO, Bin, _BodyBin) ->
-    [CPU, OS] = decode_txt(Bin),
+    [CPU, OS] = decode_text(Bin),
     #dns_rrdata_hinfo{cpu = CPU, os = OS};
 decode_rrdata(
     _Class, ?DNS_TYPE_IPSECKEY, <<Precedence:8, 0:8, Algorithm:8, PublicKey/binary>>, _MsgBin
@@ -1490,7 +1490,7 @@ decode_rrdata(_Class, ?DNS_TYPE_SOA, Bin, MsgBin) ->
         minimum = Min
     };
 decode_rrdata(_Class, ?DNS_TYPE_SPF, Bin, _MsgBin) ->
-    #dns_rrdata_spf{spf = decode_txt(Bin)};
+    #dns_rrdata_spf{spf = decode_text(Bin)};
 decode_rrdata(
     _Class,
     ?DNS_TYPE_SRV,
@@ -1528,7 +1528,7 @@ decode_rrdata(_Class, ?DNS_TYPE_TSIG, Bin, MsgBin) ->
         other = Other
     };
 decode_rrdata(_Class, ?DNS_TYPE_TXT, Bin, _MsgBin) ->
-    #dns_rrdata_txt{txt = decode_txt(Bin)};
+    #dns_rrdata_txt{txt = decode_text(Bin)};
 decode_rrdata(_Class, _Type, Bin, _MsgBin) ->
     Bin.
 
@@ -1750,7 +1750,7 @@ encode_rrdata(
 ) ->
     {<<KeyTag:16, Alg:8, DigestType:8, Digest/binary>>, CompMap};
 encode_rrdata(_Pos, _Class, #dns_rrdata_hinfo{cpu = CPU, os = OS}, CompMap) ->
-    {encode_txt([CPU, OS]), CompMap};
+    {encode_text([CPU, OS]), CompMap};
 encode_rrdata(
     _Pos,
     _Class,
@@ -2007,7 +2007,7 @@ encode_rrdata(
     {RNBin, RNCMap} = encode_dname(MNBin, MNCMap, NewPos, RName),
     {<<RNBin/binary, Serial:32, Refresh:32, Retry:32, Expire:32, Minimum:32>>, RNCMap};
 encode_rrdata(_Pos, _Class, #dns_rrdata_spf{spf = Strings}, CompMap) ->
-    {encode_txt(Strings), CompMap};
+    {encode_text(Strings), CompMap};
 encode_rrdata(
     _Pos,
     _Class,
@@ -2068,7 +2068,7 @@ encode_rrdata(
         CompMap
     };
 encode_rrdata(_Pos, _Class, #dns_rrdata_txt{txt = Strings}, CompMap) ->
-    {encode_txt(Strings), CompMap};
+    {encode_text(Strings), CompMap};
 encode_rrdata(_Pos, _Class, Bin, CompMap) when is_binary(Bin) ->
     {Bin, CompMap}.
 
@@ -2733,12 +2733,12 @@ decode_bool(1) -> true.
 encode_bool(false) -> 0;
 encode_bool(true) -> 1.
 
--spec decode_txt(binary()) -> [binary()].
-decode_txt(<<>>) ->
+-spec decode_text(binary()) -> [binary()].
+decode_text(<<>>) ->
     [];
-decode_txt(Bin) when is_binary(Bin) ->
+decode_text(Bin) when is_binary(Bin) ->
     {RB, String} = decode_string(Bin),
-    [String | decode_txt(RB)].
+    [String | decode_text(RB)].
 
 -spec decode_string(nonempty_binary()) -> {binary(), binary()}.
 decode_string(<<Len, Bin:Len/binary, Rest/binary>>) ->
@@ -2757,18 +2757,18 @@ encode_string(Bin, StringBin) when byte_size(StringBin) < 256 ->
 %% @doc Encodes an array of character-strings as in RFC1035§3.3, splitting any oversized segment
 %%
 %% @see encode_string/2
--spec encode_txt([binary()]) -> binary().
-encode_txt(Strings) ->
-    encode_txt_1(Strings, <<>>).
+-spec encode_text([binary()]) -> binary().
+encode_text(Strings) ->
+    encode_text_1(Strings, <<>>).
 
--spec encode_txt_1([binary()], binary()) -> binary().
-encode_txt_1([], Bin) ->
+-spec encode_text_1([binary()], binary()) -> binary().
+encode_text_1([], Bin) ->
     Bin;
-encode_txt_1([<<Head:255/binary, Tail/binary>> | Strings], Acc) ->
-    encode_txt_1([Tail | Strings], <<Acc/binary, 255, Head/binary>>);
-encode_txt_1([S | Strings], Acc) ->
+encode_text_1([<<Head:255/binary, Tail/binary>> | Strings], Acc) ->
+    encode_text_1([Tail | Strings], <<Acc/binary, 255, Head/binary>>);
+encode_text_1([S | Strings], Acc) ->
     Size = byte_size(S),
-    encode_txt_1(Strings, <<Acc/binary, Size, S/binary>>).
+    encode_text_1(Strings, <<Acc/binary, Size, S/binary>>).
 
 -spec decode_svcb_svc_params(binary()) -> svcb_svc_params().
 decode_svcb_svc_params(Bin) ->

--- a/test/dns_test.erl
+++ b/test/dns_test.erl
@@ -32,63 +32,109 @@ message_other_test() ->
     Bin = dns:encode_message(Msg),
     ?assertEqual(Msg, dns:decode_message(Bin)).
 
-message_txt_test() ->
-    QName = <<"lorem.example.org">>,
-    Lorem = ten_lorem_ipsums_in_chunks(),
-    Qs = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
-    As = [
-        #dns_rr{
-            name = QName,
-            type = ?DNS_TYPE_TXT,
-            ttl = 0,
-            data = #dns_rrdata_txt{txt = Lorem}
-        }
-    ],
-    QLen = length(Qs),
-    ALen = length(As),
-    Msg = #dns_message{qc = QLen, anc = ALen, questions = Qs, answers = As},
+long_txt_test() ->
+    QName = <<"txt.example.org">>,
+
+    % Create a string longer than 255 bytes
+    LongString = list_to_binary(lists:duplicate(300, $a)),
+    ?assert(byte_size(LongString) > 255),
+
+    % Create a TXT record with the long string TXT record expects a list of strings,
+    % each of which must be ≤ 255 bytes in length
+    LongStringSplit = split_binary_into_chunks(LongString, 255),
+
+    % Create a DNS message
+    Msg = #dns_message{
+        qc = 1,
+        anc = 1,
+        questions = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
+        answers = [
+            #dns_rr{
+                name = QName,
+                type = ?DNS_TYPE_TXT,
+                ttl = 0,
+                data = #dns_rrdata_txt{txt = LongStringSplit}
+            }
+        ]
+    },
+
+    % Encode and decode
     Bin = dns:encode_message(Msg),
-    ?assertEqual(Msg, dns:decode_message(Bin)).
+    DecodedMsg = dns:decode_message(Bin),
+
+    % Get the TXT record from the decoded message
+    [DecodedTxtRec] = DecodedMsg#dns_message.answers,
+    DecodedTxt = DecodedTxtRec#dns_rr.data#dns_rrdata_txt.txt,
+
+    % If encoding works correctly for long strings,
+    % the decoded string joined together should match the original
+    ReassembledString = iolist_to_binary(DecodedTxt),
+    ?assertEqual(LongString, ReassembledString).
+
+fail_long_txt_not_split_test() ->
+    QName = <<"txt.example.org">>,
+    % Create a string longer than 255 bytes
+    LongString = list_to_binary(lists:duplicate(300, $a)),
+    ?assert(byte_size(LongString) > 255),
+    % Create a DNS message
+    Msg = #dns_message{
+        qc = 1,
+        anc = 1,
+        questions = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
+        answers = [
+            #dns_rr{
+                name = QName,
+                type = ?DNS_TYPE_TXT,
+                ttl = 0,
+                data = #dns_rrdata_txt{txt = LongString}
+            }
+        ]
+    },
+    ?assertError(function_clause, dns:encode_message(Msg)).
 
 truncated_txt_test() ->
-    QName = <<"lorem.example.org">>,
-    Lorem = ten_lorem_ipsums_in_chunks(),
-    Qs = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
-    As = [
-        #dns_rr{
-            name = QName,
-            type = ?DNS_TYPE_TXT,
-            ttl = 0,
-            data = #dns_rrdata_txt{txt = Lorem}
-        }
-    ],
-    QLen = length(Qs),
-    ALen = length(As),
-    Msg = #dns_message{qc = QLen, anc = ALen, questions = Qs, answers = As},
+    QName = <<"txt.example.org">>,
+    % Create a string longer than 255 bytes
+    LongString = list_to_binary(lists:duplicate(300, $a)),
+    LongStringSplit = split_binary_into_chunks(LongString, 255),
+    % Create a DNS message
+    Msg = #dns_message{
+        qc = 1,
+        anc = 1,
+        questions = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
+        answers = [
+            #dns_rr{
+                name = QName,
+                type = ?DNS_TYPE_TXT,
+                ttl = 0,
+                data = #dns_rrdata_txt{txt = LongStringSplit}
+            }
+        ]
+    },
     Bin = dns:encode_message(Msg),
-    Head = binary:part(Bin, 0, 47),
-    OneLorem = iolist_to_binary(Lorem),
+    Head = binary:part(Bin, 0, 45),
+    OneLorem = iolist_to_binary(LongString),
     NewBin = <<Head/binary, 255, OneLorem/binary>>,
     ?assertMatch({truncated, _, _}, dns:decode_message(NewBin)).
 
 trailing_garbage_txt_test() ->
-    QName = <<"lorem.example.org">>,
+    QName = <<"txt.example.org">>,
     Text = <<"\"Hello\"">>,
-    Qs = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
-    As = [
-        #dns_rr{
-            name = QName,
-            type = ?DNS_TYPE_TXT,
-            ttl = 0,
-            data = #dns_rrdata_txt{txt = [Text]}
-        }
-    ],
-    QLen = length(Qs),
-    ALen = length(As),
-    Msg = #dns_message{qc = QLen, anc = ALen, questions = Qs, answers = As},
+    Msg = #dns_message{
+        qc = 1,
+        anc = 1,
+        questions = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
+        answers = [
+            #dns_rr{
+                name = QName,
+                type = ?DNS_TYPE_TXT,
+                ttl = 0,
+                data = #dns_rrdata_txt{txt = [Text]}
+            }
+        ]
+    },
     Bin = dns:encode_message(Msg),
-    Head = binary:part(Bin, 0, 48),
-    NewBin = <<Head/binary, "_Hello__">>,
+    NewBin = <<Bin/binary, "_">>,
     ?assertMatch({trailing_garbage, _, _}, dns:decode_message(NewBin)).
 
 message_edns_test() ->
@@ -562,8 +608,6 @@ alg_terms_test_() ->
     ],
     [?_assertEqual(true, is_binary(dns:alg_name(Alg))) || Alg <- Cases].
 
-ten_lorem_ipsums_in_chunks() ->
-    Lorem = "Lorem ipsum dolor sit \"amet\", consectetur adipisicing elit.",
-    RepeatedLorem = lists:duplicate(10, Lorem),
-    BigLorem = lists:flatten(lists:join("\n", RepeatedLorem)),
-    [iolist_to_binary(lists:sublist(BigLorem, X, 255)) || X <- lists:seq(1, length(BigLorem), 255)].
+split_binary_into_chunks(Bin, Chunk) ->
+    List = binary_to_list(Bin),
+    [iolist_to_binary(lists:sublist(List, X, Chunk)) || X <- lists:seq(1, length(List), Chunk)].

--- a/test/dns_test.erl
+++ b/test/dns_test.erl
@@ -63,15 +63,46 @@ long_txt_test() ->
     DecodedMsg = dns:decode_message(Bin),
 
     % Get the TXT record from the decoded message
-    [DecodedTxtRec] = DecodedMsg#dns_message.answers,
-    DecodedTxt = DecodedTxtRec#dns_rr.data#dns_rrdata_txt.txt,
+    [#dns_rr{data = #dns_rrdata_txt{txt = DecodedTxt}}] = DecodedMsg#dns_message.answers,
 
     % If encoding works correctly for long strings,
     % the decoded string joined together should match the original
     ReassembledString = iolist_to_binary(DecodedTxt),
     ?assertEqual(LongString, ReassembledString).
 
-fail_long_txt_not_split_test() ->
+long_txt_not_split_test() ->
+    QName = <<"txt.example.org">>,
+    % Create a string longer than 255 bytes
+    LongStringOfA = list_to_binary(lists:duplicate(300, $a)),
+    LongStringOfB = list_to_binary(lists:duplicate(300, $b)),
+    % Create a DNS message
+    Msg = #dns_message{
+        qc = 1,
+        anc = 1,
+        questions = [#dns_query{name = QName, type = ?DNS_TYPE_TXT}],
+        answers = [
+            #dns_rr{
+                name = QName,
+                type = ?DNS_TYPE_TXT,
+                ttl = 0,
+                data = #dns_rrdata_txt{txt = [LongStringOfA, LongStringOfB]}
+            }
+        ]
+    },
+    % Encode and decode
+    Bin = dns:encode_message(Msg),
+    DecodedMsg = dns:decode_message(Bin),
+    % Get the TXT record from the decoded message
+    [#dns_rr{data = #dns_rrdata_txt{txt = DecodedTxt}}] = DecodedMsg#dns_message.answers,
+    % Assert that all segments in the array are below the 255 byte limit
+    ?assert(lists:all(fun(B) -> byte_size(B) =< 255 end, DecodedTxt)),
+    % If encoding works correctly for long strings,
+    % the decoded string joined together should match the original
+    LongString = iolist_to_binary([LongStringOfA, LongStringOfB]),
+    ReassembledString = iolist_to_binary(DecodedTxt),
+    ?assertEqual(LongString, ReassembledString).
+
+fail_txt_not_list_of_strings_test() ->
     QName = <<"txt.example.org">>,
     % Create a string longer than 255 bytes
     LongString = list_to_binary(lists:duplicate(300, $a)),


### PR DESCRIPTION
As far as I could see, no more changes are needed in regards to verifying the text sections are properly split. Only extra coverage to verify existing tests is added.