### PR TITLE
String manipulations

### DIFF
--- a/src/dns.erl
+++ b/src/dns.erl
@@ -2484,31 +2484,107 @@ labels_to_dname(Labels) ->
     >>,
     Dname.
 
+-define(UP(X), (upper(X)):8).
 %% @doc Returns provided name with case-insensitive characters in uppercase.
 -spec dname_to_upper(dname()) -> dname().
 dname_to_upper(Bin) when is_binary(Bin) ->
-    <<<<(dname_to_upper_i(C))>> || <<C>> <= Bin>>;
-dname_to_upper(List) when is_list(List) ->
-    [dname_to_upper_i(C) || C <- List].
--spec dname_to_upper_i(integer()) -> integer().
-dname_to_upper_i(Int) when
-    is_integer(Int) andalso (Int >= $a) andalso (Int =< $z)
-->
-    Int - 32;
-dname_to_upper_i(Int) when is_integer(Int) -> Int.
+    do_dname_to_upper(Bin);
+dname_to_upper(Bin) when is_list(Bin) ->
+    binary_to_list(do_dname_to_upper(list_to_binary(Bin))).
 
+-spec do_dname_to_upper(dname()) -> dname().
+do_dname_to_upper(Data) when byte_size(Data) rem 8 =:= 0 ->
+    <<
+        <<?UP(A), ?UP(B), ?UP(C), ?UP(D), ?UP(E), ?UP(F), ?UP(G), ?UP(H)>>
+     || <<A, B, C, D, E, F, G, H>> <= Data
+    >>;
+do_dname_to_upper(Data) when byte_size(Data) rem 7 =:= 0 ->
+    <<
+        <<?UP(A), ?UP(B), ?UP(C), ?UP(D), ?UP(E), ?UP(F), ?UP(G)>>
+     || <<A, B, C, D, E, F, G>> <= Data
+    >>;
+do_dname_to_upper(Data) when byte_size(Data) rem 6 =:= 0 ->
+    <<<<?UP(A), ?UP(B), ?UP(C), ?UP(D), ?UP(E), ?UP(F)>> || <<A, B, C, D, E, F>> <= Data>>;
+do_dname_to_upper(Data) when byte_size(Data) rem 5 =:= 0 ->
+    <<<<?UP(A), ?UP(B), ?UP(C), ?UP(D), ?UP(E)>> || <<A, B, C, D, E>> <= Data>>;
+do_dname_to_upper(Data) when byte_size(Data) rem 4 =:= 0 ->
+    <<<<?UP(A), ?UP(B), ?UP(C), ?UP(D)>> || <<A, B, C, D>> <= Data>>;
+do_dname_to_upper(Data) when byte_size(Data) rem 3 =:= 0 ->
+    <<<<?UP(A), ?UP(B), ?UP(C)>> || <<A, B, C>> <= Data>>;
+do_dname_to_upper(Data) when byte_size(Data) rem 2 =:= 0 ->
+    <<<<?UP(A), ?UP(B)>> || <<A, B>> <= Data>>;
+do_dname_to_upper(Data) ->
+    <<<<?UP(N)>> || <<N>> <= Data>>.
+
+-define(LOW(X), (lower(X)):8).
 %% @doc Returns provided name with case-insensitive characters in lowercase.
 -spec dname_to_lower(dname()) -> dname().
 dname_to_lower(Bin) when is_binary(Bin) ->
-    <<<<(dname_to_lower_i(C))>> || <<C>> <= Bin>>;
+    do_dname_to_lower(Bin);
 dname_to_lower(List) when is_list(List) ->
-    [dname_to_lower_i(C) || C <- List].
--spec dname_to_lower_i(integer()) -> integer().
-dname_to_lower_i(Int) when
-    is_integer(Int) andalso (Int >= $A) andalso (Int =< $Z)
-->
-    Int + 32;
-dname_to_lower_i(Int) when is_integer(Int) -> Int.
+    binary_to_list(do_dname_to_lower(list_to_binary(List))).
+
+-spec do_dname_to_lower(dname()) -> dname().
+do_dname_to_lower(Data) when byte_size(Data) rem 8 =:= 0 ->
+    <<
+        <<?LOW(A), ?LOW(B), ?LOW(C), ?LOW(D), ?LOW(E), ?LOW(F), ?LOW(G), ?LOW(H)>>
+     || <<A, B, C, D, E, F, G, H>> <= Data
+    >>;
+do_dname_to_lower(Data) when byte_size(Data) rem 7 =:= 0 ->
+    <<
+        <<?LOW(A), ?LOW(B), ?LOW(C), ?LOW(D), ?LOW(E), ?LOW(F), ?LOW(G)>>
+     || <<A, B, C, D, E, F, G>> <= Data
+    >>;
+do_dname_to_lower(Data) when byte_size(Data) rem 6 =:= 0 ->
+    <<<<?LOW(A), ?LOW(B), ?LOW(C), ?LOW(D), ?LOW(E), ?LOW(F)>> || <<A, B, C, D, E, F>> <= Data>>;
+do_dname_to_lower(Data) when byte_size(Data) rem 5 =:= 0 ->
+    <<<<?LOW(A), ?LOW(B), ?LOW(C), ?LOW(D), ?LOW(E)>> || <<A, B, C, D, E>> <= Data>>;
+do_dname_to_lower(Data) when byte_size(Data) rem 4 =:= 0 ->
+    <<<<?LOW(A), ?LOW(B), ?LOW(C), ?LOW(D)>> || <<A, B, C, D>> <= Data>>;
+do_dname_to_lower(Data) when byte_size(Data) rem 3 =:= 0 ->
+    <<<<?LOW(A), ?LOW(B), ?LOW(C)>> || <<A, B, C>> <= Data>>;
+do_dname_to_lower(Data) when byte_size(Data) rem 2 =:= 0 ->
+    <<<<?LOW(A), ?LOW(B)>> || <<A, B>> <= Data>>;
+do_dname_to_lower(Data) ->
+    <<<<?LOW(N)>> || <<N>> <= Data>>.
+
+lower(X) ->
+    element(
+        X + 1,
+        {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+            47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 97, 98, 99, 100,
+            101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+            118, 119, 120, 121, 122, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+            105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+            122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138,
+            139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155,
+            156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
+            173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189,
+            190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206,
+            207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223,
+            224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240,
+            241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255}
+    ).
+
+upper(X) ->
+    element(
+        X + 1,
+        {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+            47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+            69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+            91, 92, 93, 94, 95, 96, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+            81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+            132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
+            149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165,
+            166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182,
+            183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,
+            200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216,
+            217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233,
+            234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250,
+            251, 252, 253, 254, 255}
+    ).
 
 %%%===================================================================
 %%% DNS terms


### PR DESCRIPTION
The conversion `to_lower`/`to_upper` is inspired by a change I made once to https://github.com/erlang/otp/pull/4690. In here, it is also ~3x faster. This is an operation that happens for every `dname/0` in a message, and in my benchmarks a message with three records in the answer would spend half of the time in `encode_message/1` doing `dname_to_lower/1`. After this change, it spends ~15%, making the whole encoding ~30-40% faster. This is hot code, done on every single DNS request.

The moving to `encode`/`decode` hex in the serialisation functions is not hot code, but it was a low hanging fruit. The impact in performance is the same.