### PR TITLE
Module documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
             _build
           key: ${{ runner.os }}-erlang-${{ matrix.otp }}-rebar3-${{ matrix.rebar3 }}-hash-${{hashFiles('rebar.lock')}}
       - run: make build
+      - run: rebar3 fmt --check
+        if: ${{ matrix.otp >= '27' }}
       - run: make test
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ fresh: clean
 
 .PHONY: test
 test: all
-	rebar3 fmt --check
 	rebar3 xref
 	rebar3 dialyzer
 	rebar3 eunit

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ If you'd like to see a full example of `dns_erlang` in use, please have a look a
 
 The following section explains what is contained in the library in greater detail.
 
+For more details, see [Hex Docs](https://hexdocs.pm/dns_erlang/).
+
 ### dns\_terms.hrl
 
 This file defines various terms, defined as Erlang macros, that are used in DNS packets. It includes a term for each DNS type, including one term for the numeric value and one term for the binary version. For example:
@@ -64,23 +66,3 @@ Each of the record fields in `dns_message` corresponds to the elements defined i
 Other records defined include `dns_query`, which represents a single question in the `#dns_message.questions` field, `dns_rr` which corresponds to a single resource record (RR), which appears in the `answers`, `authority`, `additional` section of the `dns_message`, and so on.
 
 Note that all support RR types must include a `dns_rrdata_` record definition, used to store the parts of the RDATA for that RR type.
-
-### dns.erl
-
-The `dns` module is the primary entry point for the functionality in this library. The module exports various types used in type specs, such as `message()`, which indicates a `#dns_message` record, `query()` which represents a single `#dns_query` record, `questions()`, which represents a list of queries, etc.
-
-It also exports functions for encoding and decoding messages, TSIG supporting functions, and various utility functions for comparing domain names, converting domain names into different cases, converting to and from label lists, etc.
-
-### dns\_record.erl
-
-The `dns_record` module exports `serialise` and `deserialise` functions for serialising and deserialising messages. You will generally not use these functions directly, rather you will use the functions for encoding and decoding messages exported by `dns.erl`.
-
-### dns\_record\_info.erl
-
-This module exports utility functions used to inspect records. You will generally not use these functions directly.
-
-### dnssec.erl
-
-The `dnssec` module exports functions used for generating NSEC responses, signing and verifying RRSIGs, and adding keytags to DNSKEY records.
-
-For example, the `sign_rr/6` function can be given a collection of resource records, the signer name, keytag, signing algorithm, private key, and a collection of options and it will return a list of RRSIG records. Currently only DSA and RSA algorithms are supported for signing RRSETs.

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -27,9 +27,9 @@
 -endif.
 ?MODULEDOC("""
 The `dns` module is the primary entry point for the functionality in this library.
-The module exports various types used in type specs, such as `message()`, which indicates
-a `#dns_message{}` record, `query()` which represents a single `#dns_query{}` record,
-`questions()`, which represents a list of queries, etc.
+The module exports various types used in type specs, such as `t:message/0`, which indicates
+a `#dns_message{}` record, `t:query/0` which represents a single `#dns_query{}` record,
+`t:questions/0`, which represents a list of queries, etc.
 
 It also exports functions for encoding and decoding messages,
 TSIG supporting functions, and various utility functions for comparing domain names, converting

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -18,7 +18,24 @@
 %%
 %% -------------------------------------------------------------------
 -module(dns).
-%% API
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+?MODULEDOC("""
+The `dns` module is the primary entry point for the functionality in this library.
+The module exports various types used in type specs, such as `message()`, which indicates
+a `#dns_message{}` record, `query()` which represents a single `#dns_query{}` record,
+`questions()`, which represents a list of queries, etc.
+
+It also exports functions for encoding and decoding messages,
+TSIG supporting functions, and various utility functions for comparing domain names, converting
+domain names into different cases, converting to and from label lists, etc.
+""").
+
 -export([decode_message/1, encode_message/1, encode_message/2]).
 -export([verify_tsig/3, verify_tsig/4]).
 -export([add_tsig/5, add_tsig/6]).

--- a/src/dns_record.erl
+++ b/src/dns_record.erl
@@ -18,6 +18,21 @@
 %%
 %% -------------------------------------------------------------------
 -module(dns_record).
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+?MODULEDOC("""
+The `dns_record` module exports `serialise` and `deserialise` functions
+for serialising and deserialising messages.
+
+You will generally not use these functions directly, rather you will use
+the functions for encoding and decoding messages exported by `m:dns`.
+""").
+
 -export([serialise/1, serialise/2, deserialise/1, deserialise/2]).
 
 -spec serialise(binary() | tuple()) -> any().

--- a/src/dns_record_info.erl
+++ b/src/dns_record_info.erl
@@ -18,6 +18,17 @@
 %%
 %% -------------------------------------------------------------------
 -module(dns_record_info).
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+?MODULEDOC("""
+This module exports utility functions used to inspect records.
+You will generally not use these functions directly.
+""").
 
 -include("dns_records.hrl").
 

--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -18,6 +18,22 @@
 %%
 %% -------------------------------------------------------------------
 -module(dnssec).
+-if(?OTP_RELEASE >= 27).
+-define(MODULEDOC(Str), -moduledoc(Str)).
+-define(DOC(Str), -doc(Str)).
+-else.
+-define(MODULEDOC(Str), -compile([])).
+-define(DOC(Str), -compile([])).
+-endif.
+?MODULEDOC("""
+The `dnssec` module exports functions used for generating NSEC responses,
+signing and verifying RRSIGs, and adding keytags to DNSKEY records.
+
+For example, the `sign_rr/6` function can be given a collection of resource records,
+the signer name, keytag, signing algorithm, private key, and a collection of options
+and it will return a list of RRSIG records. Currently only DSA and RSA algorithms are
+supported for signing RRSETs.
+""").
 
 %% API
 -export([gen_nsec/1, gen_nsec/3, gen_nsec/4]).


### PR DESCRIPTION
Move documentation from the readme into their own modules, so that it is available at hex docs and in the shell.