### PR TITLE
Minor optimisations

### DIFF
--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -273,72 +273,72 @@ add_next_hash(
 normalise_rr(#dns_rr{name = Name} = RR) ->
     RR#dns_rr{name = dns:dname_to_lower(Name)}.
 
--spec build_rrmap([dns:rr()], _) -> [{_, _}].
+-spec build_rrmap([dns:rr()], [integer()]) -> [{_, _}].
 build_rrmap(RR, BaseTypes) ->
     Base = build_rrmap_gbt(RR, BaseTypes),
-    gb_trees:to_list(Base).
+    maps:to_list(Base).
 
--spec build_rrmap([dns:rr()], _, _) -> [{_, _}].
+-spec build_rrmap([dns:rr()], [integer()], _) -> [{_, _}].
 build_rrmap(RR, BaseTypes, ZoneName) ->
     Base = build_rrmap_gbt(RR, BaseTypes),
-    WithNonTerm = build_rrmap_nonterm(ZoneName, gb_trees:keys(Base), Base),
-    gb_trees:to_list(WithNonTerm).
+    WithNonTerm = build_rrmap_nonterm(ZoneName, maps:keys(Base), Base),
+    maps:to_list(WithNonTerm).
 
--spec build_rrmap_nonterm(_, [any()], gb_trees:tree(_, _)) -> gb_trees:tree(_, _).
-build_rrmap_nonterm(_, [], GBT) ->
-    GBT;
-build_rrmap_nonterm(ZoneName, [{Name, Class} | Rest], GBT) when
-    is_binary(ZoneName)
-->
+-spec build_rrmap_nonterm(_, [{dns:dname(), dns:class()} | binary()], #{
+    {dns:dname(), dns:class()} => [integer()]
+}) ->
+    #{{dns:dname(), dns:class()} => [integer()]}.
+build_rrmap_nonterm(_, [], Map) ->
+    Map;
+build_rrmap_nonterm(ZoneName, [{Name, Class} | Rest], Map) when is_binary(ZoneName) ->
     NameAncs = name_ancestors(Name, ZoneName),
-    NewGBT = build_rrmap_nonterm(Class, NameAncs, GBT),
-    build_rrmap_nonterm(ZoneName, Rest, NewGBT);
-build_rrmap_nonterm(Class, [Name | Rest], GBT) ->
+    NewMap = build_rrmap_nonterm(Class, NameAncs, Map),
+    build_rrmap_nonterm(ZoneName, Rest, NewMap);
+build_rrmap_nonterm(Class, [Name | Rest], Map) ->
     Key = {Name, Class},
-    case gb_trees:is_defined(Key, GBT) of
+    case maps:is_key(Key, Map) of
         true ->
-            GBT;
+            Map;
         false ->
-            NewGBT = gb_trees:insert(Key, [], GBT),
-            build_rrmap_nonterm(Class, Rest, NewGBT)
+            NewMap = Map#{Key => []},
+            build_rrmap_nonterm(Class, Rest, NewMap)
     end.
 
--spec build_rrmap_gbt([dns:rr()], _) -> gb_trees:tree(_, _).
+-spec build_rrmap_gbt([dns:rr()], [integer()]) -> #{{dns:dname(), dns:class()} => [integer()]}.
 build_rrmap_gbt(RR, BaseTypes) ->
-    build_rrmap_gbt(RR, BaseTypes, gb_trees:empty()).
+    build_rrmap_gbt(RR, BaseTypes, #{}).
 
--spec build_rrmap_gbt([dns:rr()], _, gb_trees:tree(_, _)) -> gb_trees:tree(_, _).
-build_rrmap_gbt([], _BaseTypes, GBT) ->
-    GBT;
-build_rrmap_gbt([#dns_rr{} = RR | Rest], BaseTypes, GBT) ->
+-spec build_rrmap_gbt([dns:rr()], [integer()], #{{dns:dname(), dns:class()} => [integer()]}) ->
+    #{{dns:dname(), dns:class()} => [integer()]}.
+build_rrmap_gbt([], _BaseTypes, Map) ->
+    Map;
+build_rrmap_gbt([#dns_rr{} = RR | Rest], BaseTypes, Map) ->
     #dns_rr{name = Name, class = Class, type = Type} = normalise_rr(RR),
     Key = {Name, Class},
-    NewGBT =
-        case gb_trees:lookup(Key, GBT) of
-            {value, Types} ->
-                case lists:member(Type, Types) of
-                    true -> GBT;
-                    false -> gb_trees:update(Key, [Type | Types], GBT)
-                end;
-            none ->
-                Types = [Type | BaseTypes],
-                gb_trees:insert(Key, Types, GBT)
+    NewMap = maps:update_with(
+        Key,
+        fun(Types) ->
+            case lists:member(Type, Types) of
+                true -> Types;
+                false -> [Type | Types]
+            end
         end,
-    build_rrmap_gbt(Rest, BaseTypes, NewGBT).
+        [Type | BaseTypes],
+        Map
+    ),
+    build_rrmap_gbt(Rest, BaseTypes, NewMap).
 
 -type tree_key() :: {dns:dname(), dns:class(), dns:type()}.
 
 -spec rrs_to_rrsets([dns:rr()]) -> [[dns:rr()]].
 rrs_to_rrsets(RR) when is_list(RR) ->
-    rrs_to_rrsets(gb_trees:empty(), dict:new(), RR).
+    rrs_to_rrsets(RR, #{}, #{}).
 
--spec rrs_to_rrsets(gb_trees:tree(tree_key(), dns:ttl()), dict:dict(tree_key(), dns:rrdata()), [
-    dns:rr()
-]) ->
+-spec rrs_to_rrsets([dns:rr()], #{tree_key() => dns:ttl()}, #{tree_key() => [dns:rrdata()]}) ->
     [[dns:rr()]].
-rrs_to_rrsets(TTLMap, RRSets, []) ->
-    [rrs_to_rrsets(TTLMap, RRSet) || RRSet <- dict:to_list(RRSets)];
-rrs_to_rrsets(TTLMap, RRSets, [#dns_rr{} = RR | RRs]) ->
+rrs_to_rrsets([], TTLMap, RRSets) ->
+    [rrs_to_rrsets(TTLMap, RRSet) || RRSet <- maps:to_list(RRSets)];
+rrs_to_rrsets([#dns_rr{} = RR | RRs], TTLMap, RRSets) ->
     #dns_rr{
         name = Name,
         class = Class,
@@ -347,22 +347,14 @@ rrs_to_rrsets(TTLMap, RRSets, [#dns_rr{} = RR | RRs]) ->
         data = Data
     } = normalise_rr(RR),
     Key = {Name, Class, Type},
-    NewTTLMap =
-        case gb_trees:lookup(Key, TTLMap) of
-            {value, LowerTTL} when LowerTTL =< TTL ->
-                TTLMap;
-            {value, _LargerTTL} ->
-                gb_trees:update(Key, TTL, TTLMap);
-            none ->
-                gb_trees:insert(Key, TTL, TTLMap)
-        end,
-    NewRRSets = dict:append(Key, Data, RRSets),
-    rrs_to_rrsets(NewTTLMap, NewRRSets, RRs).
+    NewTTLMap = maps:update_with(Key, fun(OldTTL) -> max(OldTTL, TTL) end, TTL, TTLMap),
+    NewRRSets = maps:update_with(Key, fun(OldData) -> [Data | OldData] end, [Data], RRSets),
+    rrs_to_rrsets(RRs, NewTTLMap, NewRRSets).
 
--spec rrs_to_rrsets(gb_trees:tree(tree_key(), dns:ttl()), {tree_key(), [dns:rrdata()]}) ->
+-spec rrs_to_rrsets(#{tree_key() => dns:ttl()}, {tree_key(), [dns:rrdata()]}) ->
     [dns:rr()].
 rrs_to_rrsets(TTLMap, {{Name, Class, Type} = Key, Datas}) ->
-    {value, TTL} = gb_trees:lookup(Key, TTLMap),
+    TTL = maps:get(Key, TTLMap),
     [
         #dns_rr{
             name = Name,


### PR DESCRIPTION
`dnssec` code now uses only maps instead of gb_trees and dicts. Note in particular that dicts have very very poor performance and are strongly unrecommended.