### PR TITLE
Type and internal data structures improvements

### DIFF
--- a/include/dns_records.hrl
+++ b/include/dns_records.hrl
@@ -331,7 +331,7 @@
 %% OPT pseudo-RR for EDNS. See RFC 6891: §6.1.2.
 -record(dns_optrr, {
     udp_payload_size = 4096 :: integer(),
-    ext_rcode = ?DNS_ERCODE_NOERROR :: dns:rcode(),
+    ext_rcode = ?DNS_ERCODE_NOERROR :: dns:uint8(),
     version = 0 :: dns:uint8(),
     dnssec = false :: boolean(),
     data = [] :: [

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -159,7 +159,7 @@ domain names into different cases, converting to and from label lists, etc.
 
 -type answers() :: [rr()].
 -type authority() :: [rr()].
--type additional() :: [optrr() | [rr()]] | [rr()].
+-type additional() :: [optrr() | rr()].
 -type dname() :: binary().
 -type label() :: binary().
 -type class() :: uint16().
@@ -882,8 +882,8 @@ encode_message_rec_list(Pos, SpaceLeft, CompMap, Body, [Rec | Rest] = Recs) ->
         _ ->
             {CompMap, Body, Recs}
     end;
-encode_message_rec_list(_Pos, _SpaceLeft, CompMap, Body, [] = Recs) ->
-    {CompMap, Body, Recs}.
+encode_message_rec_list(_Pos, _SpaceLeft, CompMap, Body, []) ->
+    {CompMap, Body, []}.
 
 -spec encode_message_rec(compmap(), non_neg_integer(), query() | optrr() | rr()) ->
     {compmap(), <<_:32, _:_*8>>}.
@@ -897,13 +897,11 @@ encode_message_rec(CompMap, _Pos, #dns_optrr{
     dnssec = DNSSEC,
     data = Data
 }) ->
-    IntClass = UPS,
     DNSSECBit = encode_bool(DNSSEC),
     RRBin = encode_optrrdata(Data),
     RRBinSize = byte_size(RRBin),
     NewBin =
-        <<0, 41:16, IntClass:16, ExtRcode:8, Version:8, DNSSECBit:1, 0:15, RRBinSize:16,
-            RRBin/binary>>,
+        <<0, 41:16, UPS:16, ExtRcode:8, Version:8, DNSSECBit:1, 0:15, RRBinSize:16, RRBin/binary>>,
     {CompMap, NewBin};
 encode_message_rec(CompMap, Pos, #dns_rr{
     name = N,
@@ -929,13 +927,11 @@ encode_message_pop_optrr([
     }
     | Rest
 ]) ->
-    Class = UPS,
     DNSSECBit = encode_bool(DNSSEC),
     RRBin = encode_optrrdata(Data),
     RRBinSize = byte_size(RRBin),
     Bin =
-        <<0, 41:16, Class:16, ExtRcode:8, Version:8, DNSSECBit:1, 0:15, RRBinSize:16,
-            RRBin/binary>>,
+        <<0, 41:16, UPS:16, ExtRcode:8, Version:8, DNSSECBit:1, 0:15, RRBinSize:16, RRBin/binary>>,
     {Bin, Rest};
 encode_message_pop_optrr(Other) ->
     {<<>>, Other}.

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -597,9 +597,9 @@ encode_message_tsig_size(Name, Alg, Other) ->
     DataSize = AlgSize + 16 + MACSize + OtherSize,
     NameSize + 10 + DataSize.
 
+-define(LOC, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}).
 -spec encode_message_default(message(), number()) -> binary().
 encode_message_default(#dns_message{additional = Additional} = Msg, MaxSize) ->
-    {OptRRBin, Ad0} = encode_message_pop_optrr(Additional),
     Pos = 12,
     SpaceLeft = MaxSize - Pos,
     case encode_message_d_req(Pos, SpaceLeft, Msg) of
@@ -607,6 +607,7 @@ encode_message_default(#dns_message{additional = Additional} = Msg, MaxSize) ->
             Head = build_head(Msg, true, QC, ANC, AUC, 0),
             <<Head/binary, Body/binary>>;
         {CompMap, QC, ANC, AUC, Body} ->
+            {OptRRBin, Ad0} = encode_message_pop_optrr(Additional),
             BodySize = byte_size(Body),
             OptRRBinSize = byte_size(OptRRBin),
             Pos0 = BodySize + Pos,

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -597,7 +597,6 @@ encode_message_tsig_size(Name, Alg, Other) ->
     DataSize = AlgSize + 16 + MACSize + OtherSize,
     NameSize + 10 + DataSize.
 
--define(LOC, {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE}).
 -spec encode_message_default(message(), number()) -> binary().
 encode_message_default(#dns_message{additional = Additional} = Msg, MaxSize) ->
     Pos = 12,
@@ -645,13 +644,14 @@ build_head(#dns_message{tc = TC} = Msg, TCBool, EncQC, EncANC, EncAUC, EncADC) -
     },
     encode_message_head(Msg0).
 
--spec encode_message_d_req(12, number(), message()) ->
+%% Encodes questions, authorities, and answers, for as long as there is space
+-spec encode_message_d_req(12, integer(), message()) ->
     {false | compmap(), char(), char(), char(), bitstring()}.
 encode_message_d_req(Pos, SpaceLeft, #dns_message{} = Msg) ->
     Msg0 = Msg#dns_message{qc = 0, anc = 0, auc = 0},
     encode_message_d_req(Pos, SpaceLeft, new_compmap(), <<>>, Msg0).
 
--spec encode_message_d_req(pos_integer(), number(), compmap(), bitstring(), message()) ->
+-spec encode_message_d_req(pos_integer(), integer(), compmap(), bitstring(), message()) ->
     {false | compmap(), char(), char(), char(), bitstring()}.
 encode_message_d_req(
     Pos,

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -508,8 +508,10 @@ get_max_size(Opts, Additional) ->
             is_integer(MaxSize) andalso 512 =< MaxSize andalso MaxSize =< 65535
         ->
             MaxSize;
-        {undefined, [#dns_optrr{udp_payload_size = UPS}]} ->
-            UPS;
+        {undefined, [#dns_optrr{udp_payload_size = MaxSize}]} when
+            is_integer(MaxSize) andalso 512 =< MaxSize andalso MaxSize =< 65535
+        ->
+            MaxSize;
         {undefined, []} ->
             512;
         _ ->

--- a/test/dns_test.erl
+++ b/test/dns_test.erl
@@ -413,7 +413,7 @@ decode_encode_rrdata_wire_samples_test_() ->
                                     0,
                                     Class,
                                     Record,
-                                    gb_trees:empty()
+                                    dns:new_compmap()
                                 ),
                                 Bin
                         end,
@@ -481,7 +481,7 @@ decode_encode_rrdata_test_() ->
                     0,
                     ?DNS_CLASS_IN,
                     Data,
-                    gb_trees:empty()
+                    dns:new_compmap()
                 ),
                 Decoded = dns:decode_rrdata(?DNS_CLASS_IN, Type, Encoded, Encoded),
                 ?assertEqual(Data, Decoded)
@@ -588,21 +588,21 @@ encode_dname_1_test_() ->
     [?_assertEqual(Expect, dns:encode_dname(Input)) || {Input, Expect} <- Cases].
 
 encode_dname_3_test_() ->
-    {Bin, _CompMap} = dns:encode_dname(gb_trees:empty(), 0, <<"example">>),
+    {Bin, _CompMap} = dns:encode_dname(dns:new_compmap(), 0, <<"example">>),
     ?_assertEqual(<<7, 101, 120, 97, 109, 112, 108, 101, 0>>, Bin).
 
 encode_dname_4_test_() ->
-    {Bin0, CM0} = dns:encode_dname(<<>>, gb_trees:empty(), 0, <<"example">>),
+    {Bin0, CM0} = dns:encode_dname(<<>>, dns:new_compmap(), 0, <<"example">>),
     {Bin1, _} = dns:encode_dname(Bin0, CM0, byte_size(Bin0), <<"example">>),
     {Bin2, _} = dns:encode_dname(Bin0, CM0, byte_size(Bin0), <<"EXAMPLE">>),
     MP = (1 bsl 14),
     MPB = <<0:MP/unit:8>>,
-    {_, CM1} = dns:encode_dname(MPB, gb_trees:empty(), MP, <<"example">>),
+    {_, CM1} = dns:encode_dname(MPB, dns:new_compmap(), MP, <<"example">>),
     Cases = [
         {<<7, 101, 120, 97, 109, 112, 108, 101, 0>>, Bin0},
         {<<7, 101, 120, 97, 109, 112, 108, 101, 0, 192, 0>>, Bin1},
         {Bin1, Bin2},
-        {gb_trees:empty(), CM1}
+        {dns:new_compmap(), CM1}
     ],
     [?_assertEqual(Expect, Result) || {Expect, Result} <- Cases].
 

--- a/test/dns_test.erl
+++ b/test/dns_test.erl
@@ -237,13 +237,10 @@ message_edns_test() ->
             data = [LLQ, ECS]
         }
     ],
-    QLen = length(Qs),
-    AnsLen = length(Ans),
-    AdsLen = length(Ads),
     Msg = #dns_message{
-        qc = QLen,
-        anc = AnsLen,
-        adc = AdsLen,
+        qc = length(Qs),
+        anc = length(Ans),
+        adc = length(Ads),
         questions = Qs,
         answers = Ans,
         additional = Ads


### PR DESCRIPTION
Further non-breaking changes:
1. Using maps for the internal data structure used to compare already visited notes, as API is easier and performance is slightly better than for gb_trees.
2. Improving type information in a bunch more helper functions.
3. Adding extensive tests for the `max_size` option.