### PR TITLE
Add bin int conversions and `labels/0` type shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## 4.2.0
+
+- Add shortcuts for normalizing and converting domains into labels.
+- Add a helper for comparing label lists.
+- Add helpers to convert from and to codes into their string representation.
+
 ## 4.1.0
 
 - Add support for RFC7873 EDNS cookies encoding and decoding

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -38,7 +38,7 @@ domain names into different cases, converting to and from label lists, etc.
 
 -export([decode_message/1, encode_message/1, encode_message/2]).
 -export([verify_tsig/3, verify_tsig/4, add_tsig/5, add_tsig/6]).
--export([compare_dname/2, escape_label/1]).
+-export([compare_dname/2, compare_labels/2, escape_label/1]).
 -export([
     dname_to_upper/1,
     dname_to_lower/1,
@@ -426,9 +426,24 @@ do_dname_to_labels(Label, <<C, Cs/binary>>) ->
 compare_dname(Name, Name) ->
     true;
 compare_dname(NameA, NameB) ->
-    NameALwr = dname_to_lower(iolist_to_binary(NameA)),
-    NameBLwr = dname_to_lower(iolist_to_binary(NameB)),
-    NameALwr =:= NameBLwr.
+    dname_to_lower(NameA) =:= dname_to_lower(NameB).
+
+?DOC(#{group => <<"Functions: utilities">>}).
+?DOC("Compare two domain names insensitive of case.").
+-spec compare_labels(labels(), labels()) -> boolean().
+compare_labels(LabelsA, LabelsB) when is_list(LabelsA), is_list(LabelsB) ->
+    do_compare_labels(LabelsA, LabelsB).
+
+do_compare_labels([], []) ->
+    true;
+do_compare_labels([LA | LabelsA], [LA | LabelsB]) ->
+    do_compare_labels(LabelsA, LabelsB);
+do_compare_labels([LA | LabelsA], [LB | LabelsB]) ->
+    dname_to_lower(LA) =:= dname_to_lower(LB) andalso do_compare_labels(LabelsA, LabelsB);
+do_compare_labels([], [_ | _]) ->
+    false;
+do_compare_labels([_ | _], []) ->
+    false.
 
 ?DOC(#{group => <<"Functions: utilities">>}).
 ?DOC("Escapes dots in a DNS label").

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -128,6 +128,8 @@ characters only letters, digits, and hyphen. There are also some
 restrictions on the length. Labels must be 63 characters or less.
 """).
 -type label() :: binary().
+?DOC("A list of `t:dns:label/0`").
+-type labels() :: [label()].
 ?DOC("DNS Message class. See RFC 1035: §4.1.2.").
 -type class() :: uint16().
 ?DOC("DNS Message class. See RFC 1035: §4.1.2.").
@@ -145,6 +147,7 @@ restrictions on the length. Labels must be 63 characters or less.
     type/0,
     ttl/0,
     label/0,
+    labels/0,
     unix_time/0
 ]).
 
@@ -384,7 +387,7 @@ add_tsig(Msg, Alg, Name, Secret, ErrCode, Options) ->
 
 ?DOC(#{group => <<"Functions: utilities">>}).
 ?DOC("Splits a dname into a list of labels and removes unneeded escapes.").
--spec dname_to_labels(dns:dname()) -> [dns:label()].
+-spec dname_to_labels(dname()) -> labels().
 dname_to_labels(<<>>) ->
     [];
 dname_to_labels(<<$.>>) ->
@@ -433,7 +436,7 @@ do_escape_label(Cur, <<C, Rest/binary>>) ->
     do_escape_label(<<Cur/binary, C>>, Rest).
 
 ?DOC(false).
--spec labels_to_dname([label()]) -> dname().
+-spec labels_to_dname(labels()) -> dname().
 labels_to_dname(Labels) ->
     <<$., DName/binary>> = <<<<$., (escape_label(Label))/binary>> || Label <- Labels>>,
     DName.

--- a/src/dns.erl
+++ b/src/dns.erl
@@ -39,8 +39,13 @@ domain names into different cases, converting to and from label lists, etc.
 -export([decode_message/1, encode_message/1, encode_message/2]).
 -export([verify_tsig/3, verify_tsig/4, add_tsig/5, add_tsig/6]).
 -export([compare_dname/2, escape_label/1]).
--export([dname_to_upper/1, dname_to_lower/1]).
--export([dname_to_labels/1, labels_to_dname/1]).
+-export([
+    dname_to_upper/1,
+    dname_to_lower/1,
+    dname_to_labels/1,
+    labels_to_dname/1,
+    dname_to_lower_labels/1
+]).
 -export([unix_time/0, unix_time/1]).
 -export([random_id/0]).
 
@@ -384,6 +389,12 @@ add_tsig(Msg, Alg, Name, Secret, ErrCode, Options) ->
 %%%===================================================================
 %%% Domain name functions
 %%%===================================================================
+
+?DOC(#{group => <<"Functions: utilities">>}).
+?DOC("Splits a dname into a list of labels in lowercase and removes unneeded escapes.").
+-spec dname_to_lower_labels(dname()) -> labels().
+dname_to_lower_labels(Name) ->
+    dname_to_labels(dname_to_lower(Name)).
 
 ?DOC(#{group => <<"Functions: utilities">>}).
 ?DOC("Splits a dname into a list of labels and removes unneeded escapes.").

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -31,7 +31,7 @@
 
 -compile({inline, [encode_bool/1]}).
 
--type compmap() :: #{[binary()] => non_neg_integer()}.
+-type compmap() :: #{dns:labels() => non_neg_integer()}.
 -export_type([compmap/0]).
 
 -spec encode(dns:message()) -> dns:message_bin().
@@ -1187,17 +1187,18 @@ do_encode_optrrdata(#dns_opt_unknown{id = Id, bin = Data}) when
 ->
     {Id, Data}.
 
--spec encode_dname(binary()) -> nonempty_binary().
+-spec encode_dname(dns:dname()) -> nonempty_binary().
 encode_dname(Name) when is_binary(Name) ->
     Labels = <<<<(byte_size(L)), L/binary>> || L <- dns:dname_to_labels(Name)>>,
     <<Labels/binary, 0>>.
 
--spec encode_dname(compmap(), non_neg_integer(), binary()) -> {binary(), undefined | compmap()}.
+-spec encode_dname(compmap(), non_neg_integer(), dns:dname()) ->
+    {dns:dname(), undefined | compmap()}.
 encode_dname(CompMap, Pos, Name) ->
     encode_dname(<<>>, CompMap, Pos, Name).
 
--spec encode_dname(binary(), undefined | compmap(), non_neg_integer(), binary()) ->
-    {binary(), undefined | compmap()}.
+-spec encode_dname(dns:dname(), undefined | compmap(), non_neg_integer(), dns:dname()) ->
+    {dns:dname(), undefined | compmap()}.
 encode_dname(Bin, undefined, _Pos, Name) ->
     DNameBin = encode_dname(Name),
     {<<Bin/binary, DNameBin/binary>>, undefined};
@@ -1206,7 +1207,7 @@ encode_dname(Bin, CompMap, Pos, Name) ->
     LwrLabels = dns:dname_to_labels(dns:dname_to_lower(Name)),
     encode_dname_labels(Bin, CompMap, Pos, Labels, LwrLabels).
 
--spec encode_dname_labels(binary(), compmap(), non_neg_integer(), [binary()], [binary()]) ->
+-spec encode_dname_labels(dns:dname(), compmap(), non_neg_integer(), dns:labels(), dns:labels()) ->
     {nonempty_binary(), compmap()}.
 encode_dname_labels(Bin, CompMap, _Pos, [], []) ->
     {<<Bin/binary, 0>>, CompMap};

--- a/src/dns_names.erl
+++ b/src/dns_names.erl
@@ -14,15 +14,25 @@ Helpers to convert between DNS codes and their names.
 
 -export([
     class_name/1,
+    name_class/1,
     type_name/1,
+    name_type/1,
     rcode_name/1,
+    name_rcode/1,
     opcode_name/1,
+    name_opcode/1,
     tsigerr_name/1,
+    name_tsigerr/1,
     ercode_name/1,
+    name_ercode/1,
     eoptcode_name/1,
+    name_eoptcode/1,
     llqopcode_name/1,
+    name_llqopcode/1,
     llqerrcode_name/1,
-    alg_name/1
+    name_llqerrcode/1,
+    alg_name/1,
+    name_alg/1
 ]).
 
 %%%===================================================================
@@ -30,7 +40,7 @@ Helpers to convert between DNS codes and their names.
 %%%===================================================================
 
 ?DOC("Returns the name of the class as a binary string.").
--spec class_name(dns:class()) -> binary() | undefined.
+-spec class_name(dns:class()) -> unicode:latin1_binary() | undefined.
 class_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_CLASS_IN_NUMBER -> ?DNS_CLASS_IN_BSTR;
@@ -42,8 +52,21 @@ class_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns the class type from a binary string.").
+-spec name_class(unicode:latin1_binary()) -> dns:class() | undefined.
+name_class(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_CLASS_IN_BSTR -> ?DNS_CLASS_IN_NUMBER;
+        ?DNS_CLASS_CS_BSTR -> ?DNS_CLASS_CS_NUMBER;
+        ?DNS_CLASS_CH_BSTR -> ?DNS_CLASS_CH_NUMBER;
+        ?DNS_CLASS_HS_BSTR -> ?DNS_CLASS_HS_NUMBER;
+        ?DNS_CLASS_NONE_BSTR -> ?DNS_CLASS_NONE_NUMBER;
+        ?DNS_CLASS_ANY_BSTR -> ?DNS_CLASS_ANY_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of the type as a binary string.").
--spec type_name(dns:type()) -> binary() | undefined.
+-spec type_name(dns:type()) -> unicode:latin1_binary() | undefined.
 type_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_TYPE_A_NUMBER -> ?DNS_TYPE_A_BSTR;
@@ -119,8 +142,85 @@ type_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Converts from the string representation into the standard `t:dns:type/0` representation").
+-spec name_type(unicode:latin1_binary()) -> dns:type() | undefined.
+name_type(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_TYPE_A_BSTR -> ?DNS_TYPE_A_NUMBER;
+        ?DNS_TYPE_NS_BSTR -> ?DNS_TYPE_NS_NUMBER;
+        ?DNS_TYPE_MD_BSTR -> ?DNS_TYPE_MD_NUMBER;
+        ?DNS_TYPE_MF_BSTR -> ?DNS_TYPE_MF_NUMBER;
+        ?DNS_TYPE_CNAME_BSTR -> ?DNS_TYPE_CNAME_NUMBER;
+        ?DNS_TYPE_SOA_BSTR -> ?DNS_TYPE_SOA_NUMBER;
+        ?DNS_TYPE_MB_BSTR -> ?DNS_TYPE_MB_NUMBER;
+        ?DNS_TYPE_MG_BSTR -> ?DNS_TYPE_MG_NUMBER;
+        ?DNS_TYPE_MR_BSTR -> ?DNS_TYPE_MR_NUMBER;
+        ?DNS_TYPE_NULL_BSTR -> ?DNS_TYPE_NULL_NUMBER;
+        ?DNS_TYPE_WKS_BSTR -> ?DNS_TYPE_WKS_NUMBER;
+        ?DNS_TYPE_PTR_BSTR -> ?DNS_TYPE_PTR_NUMBER;
+        ?DNS_TYPE_HINFO_BSTR -> ?DNS_TYPE_HINFO_NUMBER;
+        ?DNS_TYPE_MINFO_BSTR -> ?DNS_TYPE_MINFO_NUMBER;
+        ?DNS_TYPE_MX_BSTR -> ?DNS_TYPE_MX_NUMBER;
+        ?DNS_TYPE_TXT_BSTR -> ?DNS_TYPE_TXT_NUMBER;
+        ?DNS_TYPE_RP_BSTR -> ?DNS_TYPE_RP_NUMBER;
+        ?DNS_TYPE_AFSDB_BSTR -> ?DNS_TYPE_AFSDB_NUMBER;
+        ?DNS_TYPE_X25_BSTR -> ?DNS_TYPE_X25_NUMBER;
+        ?DNS_TYPE_ISDN_BSTR -> ?DNS_TYPE_ISDN_NUMBER;
+        ?DNS_TYPE_RT_BSTR -> ?DNS_TYPE_RT_NUMBER;
+        ?DNS_TYPE_NSAP_BSTR -> ?DNS_TYPE_NSAP_NUMBER;
+        ?DNS_TYPE_SIG_BSTR -> ?DNS_TYPE_SIG_NUMBER;
+        ?DNS_TYPE_KEY_BSTR -> ?DNS_TYPE_KEY_NUMBER;
+        ?DNS_TYPE_PX_BSTR -> ?DNS_TYPE_PX_NUMBER;
+        ?DNS_TYPE_GPOS_BSTR -> ?DNS_TYPE_GPOS_NUMBER;
+        ?DNS_TYPE_AAAA_BSTR -> ?DNS_TYPE_AAAA_NUMBER;
+        ?DNS_TYPE_LOC_BSTR -> ?DNS_TYPE_LOC_NUMBER;
+        ?DNS_TYPE_NXT_BSTR -> ?DNS_TYPE_NXT_NUMBER;
+        ?DNS_TYPE_EID_BSTR -> ?DNS_TYPE_EID_NUMBER;
+        ?DNS_TYPE_NIMLOC_BSTR -> ?DNS_TYPE_NIMLOC_NUMBER;
+        ?DNS_TYPE_SRV_BSTR -> ?DNS_TYPE_SRV_NUMBER;
+        ?DNS_TYPE_ATMA_BSTR -> ?DNS_TYPE_ATMA_NUMBER;
+        ?DNS_TYPE_NAPTR_BSTR -> ?DNS_TYPE_NAPTR_NUMBER;
+        ?DNS_TYPE_KX_BSTR -> ?DNS_TYPE_KX_NUMBER;
+        ?DNS_TYPE_CERT_BSTR -> ?DNS_TYPE_CERT_NUMBER;
+        ?DNS_TYPE_DNAME_BSTR -> ?DNS_TYPE_DNAME_NUMBER;
+        ?DNS_TYPE_SINK_BSTR -> ?DNS_TYPE_SINK_NUMBER;
+        ?DNS_TYPE_OPT_BSTR -> ?DNS_TYPE_OPT_NUMBER;
+        ?DNS_TYPE_APL_BSTR -> ?DNS_TYPE_APL_NUMBER;
+        ?DNS_TYPE_DS_BSTR -> ?DNS_TYPE_DS_NUMBER;
+        ?DNS_TYPE_CDS_BSTR -> ?DNS_TYPE_CDS_NUMBER;
+        ?DNS_TYPE_SSHFP_BSTR -> ?DNS_TYPE_SSHFP_NUMBER;
+        ?DNS_TYPE_CAA_BSTR -> ?DNS_TYPE_CAA_NUMBER;
+        ?DNS_TYPE_IPSECKEY_BSTR -> ?DNS_TYPE_IPSECKEY_NUMBER;
+        ?DNS_TYPE_RRSIG_BSTR -> ?DNS_TYPE_RRSIG_NUMBER;
+        ?DNS_TYPE_NSEC_BSTR -> ?DNS_TYPE_NSEC_NUMBER;
+        ?DNS_TYPE_DNSKEY_BSTR -> ?DNS_TYPE_DNSKEY_NUMBER;
+        ?DNS_TYPE_CDNSKEY_BSTR -> ?DNS_TYPE_CDNSKEY_NUMBER;
+        ?DNS_TYPE_NSEC3_BSTR -> ?DNS_TYPE_NSEC3_NUMBER;
+        ?DNS_TYPE_NSEC3PARAM_BSTR -> ?DNS_TYPE_NSEC3PARAM_NUMBER;
+        ?DNS_TYPE_DHCID_BSTR -> ?DNS_TYPE_DHCID_NUMBER;
+        ?DNS_TYPE_HIP_BSTR -> ?DNS_TYPE_HIP_NUMBER;
+        ?DNS_TYPE_NINFO_BSTR -> ?DNS_TYPE_NINFO_NUMBER;
+        ?DNS_TYPE_RKEY_BSTR -> ?DNS_TYPE_RKEY_NUMBER;
+        ?DNS_TYPE_TALINK_BSTR -> ?DNS_TYPE_TALINK_NUMBER;
+        ?DNS_TYPE_SPF_BSTR -> ?DNS_TYPE_SPF_NUMBER;
+        ?DNS_TYPE_UINFO_BSTR -> ?DNS_TYPE_UINFO_NUMBER;
+        ?DNS_TYPE_UID_BSTR -> ?DNS_TYPE_UID_NUMBER;
+        ?DNS_TYPE_GID_BSTR -> ?DNS_TYPE_GID_NUMBER;
+        ?DNS_TYPE_UNSPEC_BSTR -> ?DNS_TYPE_UNSPEC_NUMBER;
+        ?DNS_TYPE_NXNAME_BSTR -> ?DNS_TYPE_NXNAME_NUMBER;
+        ?DNS_TYPE_TKEY_BSTR -> ?DNS_TYPE_TKEY_NUMBER;
+        ?DNS_TYPE_TSIG_BSTR -> ?DNS_TYPE_TSIG_NUMBER;
+        ?DNS_TYPE_IXFR_BSTR -> ?DNS_TYPE_IXFR_NUMBER;
+        ?DNS_TYPE_AXFR_BSTR -> ?DNS_TYPE_AXFR_NUMBER;
+        ?DNS_TYPE_MAILB_BSTR -> ?DNS_TYPE_MAILB_NUMBER;
+        ?DNS_TYPE_MAILA_BSTR -> ?DNS_TYPE_MAILA_NUMBER;
+        ?DNS_TYPE_ANY_BSTR -> ?DNS_TYPE_ANY_NUMBER;
+        ?DNS_TYPE_DLV_BSTR -> ?DNS_TYPE_DLV_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of an rcode as a binary string.").
--spec rcode_name(dns:rcode()) -> binary() | undefined.
+-spec rcode_name(dns:rcode()) -> unicode:latin1_binary() | undefined.
 rcode_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_RCODE_NOERROR_NUMBER -> ?DNS_RCODE_NOERROR_BSTR;
@@ -137,8 +237,26 @@ rcode_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns the name of an rcode as a binary string.").
+-spec name_rcode(unicode:latin1_binary()) -> dns:rcode() | undefined.
+name_rcode(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_RCODE_NOERROR_BSTR -> ?DNS_RCODE_NOERROR_NUMBER;
+        ?DNS_RCODE_FORMERR_BSTR -> ?DNS_RCODE_FORMERR_NUMBER;
+        ?DNS_RCODE_SERVFAIL_BSTR -> ?DNS_RCODE_SERVFAIL_NUMBER;
+        ?DNS_RCODE_NXDOMAIN_BSTR -> ?DNS_RCODE_NXDOMAIN_NUMBER;
+        ?DNS_RCODE_NOTIMP_BSTR -> ?DNS_RCODE_NOTIMP_NUMBER;
+        ?DNS_RCODE_REFUSED_BSTR -> ?DNS_RCODE_REFUSED_NUMBER;
+        ?DNS_RCODE_YXDOMAIN_BSTR -> ?DNS_RCODE_YXDOMAIN_NUMBER;
+        ?DNS_RCODE_YXRRSET_BSTR -> ?DNS_RCODE_YXRRSET_NUMBER;
+        ?DNS_RCODE_NXRRSET_BSTR -> ?DNS_RCODE_NXRRSET_NUMBER;
+        ?DNS_RCODE_NOTAUTH_BSTR -> ?DNS_RCODE_NOTAUTH_NUMBER;
+        ?DNS_RCODE_NOTZONE_BSTR -> ?DNS_RCODE_NOTZONE_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of an opcode as a binary string.").
--spec opcode_name(dns:opcode()) -> binary() | undefined.
+-spec opcode_name(dns:opcode()) -> unicode:latin1_binary() | undefined.
 opcode_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_OPCODE_QUERY_NUMBER -> ?DNS_OPCODE_QUERY_BSTR;
@@ -148,8 +266,19 @@ opcode_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns the opcode from a binary string.").
+-spec name_opcode(unicode:latin1_binary()) -> dns:opcode() | undefined.
+name_opcode(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_OPCODE_QUERY_BSTR -> ?DNS_OPCODE_QUERY_NUMBER;
+        ?DNS_OPCODE_IQUERY_BSTR -> ?DNS_OPCODE_IQUERY_NUMBER;
+        ?DNS_OPCODE_STATUS_BSTR -> ?DNS_OPCODE_STATUS_NUMBER;
+        ?DNS_OPCODE_UPDATE_BSTR -> ?DNS_OPCODE_UPDATE_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of a DNS algorithm as a binary string.").
--spec alg_name(dns:alg()) -> binary() | undefined.
+-spec alg_name(dns:alg()) -> unicode:latin1_binary() | undefined.
 alg_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_ALG_DSA_NUMBER -> ?DNS_ALG_DSA_BSTR;
@@ -161,8 +290,21 @@ alg_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns the DNS algorithm from a binary string.").
+-spec name_alg(unicode:latin1_binary()) -> dns:alg() | undefined.
+name_alg(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_ALG_DSA_BSTR -> ?DNS_ALG_DSA_NUMBER;
+        ?DNS_ALG_NSEC3DSA_BSTR -> ?DNS_ALG_NSEC3DSA_NUMBER;
+        ?DNS_ALG_RSASHA1_BSTR -> ?DNS_ALG_RSASHA1_NUMBER;
+        ?DNS_ALG_NSEC3RSASHA1_BSTR -> ?DNS_ALG_NSEC3RSASHA1_NUMBER;
+        ?DNS_ALG_RSASHA256_BSTR -> ?DNS_ALG_RSASHA256_NUMBER;
+        ?DNS_ALG_RSASHA512_BSTR -> ?DNS_ALG_RSASHA512_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of a TSIG error as a binary string.").
--spec tsigerr_name(dns:tsig_error()) -> binary() | undefined.
+-spec tsigerr_name(dns:tsig_error()) -> unicode:latin1_binary() | undefined.
 tsigerr_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_TSIGERR_NOERROR_NUMBER -> ?DNS_TSIGERR_NOERROR_BSTR;
@@ -172,8 +314,19 @@ tsigerr_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns the TSIG error from a binary string.").
+-spec name_tsigerr(unicode:latin1_binary()) -> dns:tsig_error() | undefined.
+name_tsigerr(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_TSIGERR_NOERROR_BSTR -> ?DNS_TSIGERR_NOERROR_NUMBER;
+        ?DNS_TSIGERR_BADSIG_BSTR -> ?DNS_TSIGERR_BADSIG_NUMBER;
+        ?DNS_TSIGERR_BADKEY_BSTR -> ?DNS_TSIGERR_BADKEY_NUMBER;
+        ?DNS_TSIGERR_BADTIME_BSTR -> ?DNS_TSIGERR_BADTIME_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of an extended rcode as a binary string.").
--spec ercode_name(dns:ercode()) -> binary() | undefined.
+-spec ercode_name(dns:ercode()) -> unicode:latin1_binary() | undefined.
 ercode_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_ERCODE_NOERROR_NUMBER -> ?DNS_ERCODE_NOERROR_BSTR;
@@ -182,8 +335,18 @@ ercode_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns the extended rcode from a binary string.").
+-spec name_ercode(unicode:latin1_binary()) -> dns:ercode() | undefined.
+name_ercode(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_ERCODE_NOERROR_BSTR -> ?DNS_ERCODE_NOERROR_NUMBER;
+        ?DNS_ERCODE_BADVERS_BSTR -> ?DNS_ERCODE_BADVERS_NUMBER;
+        ?DNS_ERCODE_BADCOOKIE_BSTR -> ?DNS_ERCODE_BADCOOKIE_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of an extended option as a binary string.").
--spec eoptcode_name(dns:eoptcode()) -> binary() | undefined.
+-spec eoptcode_name(dns:eoptcode()) -> unicode:latin1_binary() | undefined.
 eoptcode_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_EOPTCODE_LLQ_NUMBER -> ?DNS_EOPTCODE_LLQ_BSTR;
@@ -193,8 +356,19 @@ eoptcode_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns the extended option from a binary string.").
+-spec name_eoptcode(unicode:latin1_binary()) -> dns:eoptcode() | undefined.
+name_eoptcode(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_EOPTCODE_LLQ_BSTR -> ?DNS_EOPTCODE_LLQ_NUMBER;
+        ?DNS_EOPTCODE_UL_BSTR -> ?DNS_EOPTCODE_UL_NUMBER;
+        ?DNS_EOPTCODE_NSID_BSTR -> ?DNS_EOPTCODE_NSID_NUMBER;
+        ?DNS_EOPTCODE_OWNER_BSTR -> ?DNS_EOPTCODE_OWNER_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of an LLQ opcode as a binary string.").
--spec llqopcode_name(dns:llqopcode()) -> binary() | undefined.
+-spec llqopcode_name(dns:llqopcode()) -> unicode:latin1_binary() | undefined.
 llqopcode_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_LLQOPCODE_SETUP_NUMBER -> ?DNS_LLQOPCODE_SETUP_BSTR;
@@ -203,8 +377,18 @@ llqopcode_name(Int) when is_integer(Int) ->
         _ -> undefined
     end.
 
+?DOC("Returns LLQ opcode from a binary string.").
+-spec name_llqopcode(unicode:latin1_binary()) -> dns:llqopcode() | undefined.
+name_llqopcode(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_LLQOPCODE_SETUP_BSTR -> ?DNS_LLQOPCODE_SETUP_NUMBER;
+        ?DNS_LLQOPCODE_REFRESH_BSTR -> ?DNS_LLQOPCODE_REFRESH_NUMBER;
+        ?DNS_LLQOPCODE_EVENT_BSTR -> ?DNS_LLQOPCODE_EVENT_NUMBER;
+        _ -> undefined
+    end.
+
 ?DOC("Returns the name of an LLQ error code as a binary string.").
--spec llqerrcode_name(dns:llqerrcode()) -> binary() | undefined.
+-spec llqerrcode_name(dns:llqerrcode()) -> unicode:latin1_binary() | undefined.
 llqerrcode_name(Int) when is_integer(Int) ->
     case Int of
         ?DNS_LLQERRCODE_NOERROR_NUMBER -> ?DNS_LLQERRCODE_NOERROR_BSTR;
@@ -214,5 +398,19 @@ llqerrcode_name(Int) when is_integer(Int) ->
         ?DNS_LLQERRCODE_NOSUCHLLQ_NUMBER -> ?DNS_LLQERRCODE_NOSUCHLLQ_BSTR;
         ?DNS_LLQERRCODE_BADVERS_NUMBER -> ?DNS_LLQERRCODE_BADVERS_BSTR;
         ?DNS_LLQERRCODE_UNKNOWNERR_NUMBER -> ?DNS_LLQERRCODE_UNKNOWNERR_BSTR;
+        _ -> undefined
+    end.
+
+?DOC("Returns the LLQ error code from a binary string.").
+-spec name_llqerrcode(unicode:latin1_binary()) -> dns:llqerrcode() | undefined.
+name_llqerrcode(Bin) when is_binary(Bin) ->
+    case Bin of
+        ?DNS_LLQERRCODE_NOERROR_BSTR -> ?DNS_LLQERRCODE_NOERROR_NUMBER;
+        ?DNS_LLQERRCODE_SERVFULL_BSTR -> ?DNS_LLQERRCODE_SERVFULL_NUMBER;
+        ?DNS_LLQERRCODE_STATIC_BSTR -> ?DNS_LLQERRCODE_STATIC_NUMBER;
+        ?DNS_LLQERRCODE_FORMATERR_BSTR -> ?DNS_LLQERRCODE_FORMATERR_NUMBER;
+        ?DNS_LLQERRCODE_NOSUCHLLQ_BSTR -> ?DNS_LLQERRCODE_NOSUCHLLQ_NUMBER;
+        ?DNS_LLQERRCODE_BADVERS_BSTR -> ?DNS_LLQERRCODE_BADVERS_NUMBER;
+        ?DNS_LLQERRCODE_UNKNOWNERR_BSTR -> ?DNS_LLQERRCODE_UNKNOWNERR_NUMBER;
         _ -> undefined
     end.

--- a/test/dns_names_test.erl
+++ b/test/dns_names_test.erl
@@ -4,26 +4,29 @@
 -include_lib("dns_erlang/include/dns.hrl").
 
 -define(UNKNOWN_INT, ((1 bsl 32) - 1)).
+-define(UNKNOWN_BIN, base64:encode(crypto:strong_rand_bytes(128))).
 
 class_name_test_() ->
     {ok, Cases} = file:consult(filename:join("test", "rrdata_wire_samples.txt")),
-    Classes = sets:to_list(sets:from_list([C || {C, _, _} <- Cases])),
-    ExtraCases = [
+    Classes = sets:to_list(sets:from_list([N || {N, _, _} <- Cases])),
+    AllCases = [
         ?DNS_CLASS_IN_NUMBER,
         ?DNS_CLASS_CS_NUMBER,
         ?DNS_CLASS_CH_NUMBER,
         ?DNS_CLASS_HS_NUMBER,
         ?DNS_CLASS_NONE_NUMBER,
         ?DNS_CLASS_ANY_NUMBER
+        | Classes
     ],
     [?_assertEqual(undefined, dns_names:class_name(?UNKNOWN_INT))] ++
-        [?_assert(is_binary(dns_names:class_name(Alg))) || Alg <- ExtraCases] ++
-        [?_assertEqual(true, is_binary(dns_names:class_name(C))) || C <- Classes].
+        [?_assertEqual(undefined, dns_names:name_class(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:class_name(N))) || N <- AllCases] ++
+        [?_assertEqual(N, dns_names:name_class(dns_names:class_name(N))) || N <- AllCases].
 
 type_name_test_() ->
     {ok, Cases} = file:consult(filename:join("test", "rrdata_wire_samples.txt")),
     Types = sets:to_list(sets:from_list([T || {_, T, _} <- Cases])),
-    ExtraCases = [
+    AllCases = [
         ?DNS_TYPE_A_NUMBER,
         ?DNS_TYPE_NS_NUMBER,
         ?DNS_TYPE_MD_NUMBER,
@@ -94,10 +97,12 @@ type_name_test_() ->
         ?DNS_TYPE_MAILA_NUMBER,
         ?DNS_TYPE_ANY_NUMBER,
         ?DNS_TYPE_DLV_NUMBER
+        | Types
     ],
     [?_assertEqual(undefined, dns_names:type_name(?UNKNOWN_INT))] ++
-        [?_assert(is_binary(dns_names:type_name(Type))) || Type <- ExtraCases] ++
-        [?_assertEqual(T =/= 999, is_binary(dns_names:type_name(T))) || T <- Types].
+        [?_assertEqual(undefined, dns_names:name_type(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:type_name(N))) || N <- AllCases, N =/= 999] ++
+        [?_assertEqual(N, dns_names:name_type(dns_names:type_name(N))) || N <- AllCases, N =/= 999].
 
 alg_terms_test_() ->
     Cases = [
@@ -108,8 +113,10 @@ alg_terms_test_() ->
         ?DNS_ALG_RSASHA256,
         ?DNS_ALG_RSASHA512
     ],
-    L = [?_assert(is_binary(dns_names:alg_name(Alg))) || Alg <- Cases],
-    [?_assertEqual(undefined, dns_names:alg_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:alg_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_alg(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:alg_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_alg(dns_names:alg_name(N))) || N <- Cases].
 
 rcode_terms_test_() ->
     Cases = [
@@ -125,8 +132,10 @@ rcode_terms_test_() ->
         ?DNS_RCODE_NOTAUTH_NUMBER,
         ?DNS_RCODE_NOTZONE_NUMBER
     ],
-    L = [?_assert(is_binary(dns_names:rcode_name(Number))) || Number <- Cases],
-    [?_assertEqual(undefined, dns_names:rcode_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:rcode_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_rcode(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:rcode_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_rcode(dns_names:rcode_name(N))) || N <- Cases].
 
 optcode_terms_test_() ->
     Cases = [
@@ -135,8 +144,10 @@ optcode_terms_test_() ->
         ?DNS_OPCODE_STATUS_NUMBER,
         ?DNS_OPCODE_UPDATE_NUMBER
     ],
-    L = [?_assert(is_binary(dns_names:opcode_name(Number))) || Number <- Cases],
-    [?_assertEqual(undefined, dns_names:opcode_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:opcode_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_opcode(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:opcode_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_opcode(dns_names:opcode_name(N))) || N <- Cases].
 
 tsigerr_terms_test_() ->
     Cases = [
@@ -145,8 +156,10 @@ tsigerr_terms_test_() ->
         ?DNS_TSIGERR_BADKEY_NUMBER,
         ?DNS_TSIGERR_BADTIME_NUMBER
     ],
-    L = [?_assert(is_binary(dns_names:tsigerr_name(Number))) || Number <- Cases],
-    [?_assertEqual(undefined, dns_names:tsigerr_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:tsigerr_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_tsigerr(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:tsigerr_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_tsigerr(dns_names:tsigerr_name(N))) || N <- Cases].
 
 ercode_name_test_() ->
     Cases = [
@@ -154,8 +167,10 @@ ercode_name_test_() ->
         ?DNS_ERCODE_BADVERS_NUMBER,
         ?DNS_ERCODE_BADCOOKIE_NUMBER
     ],
-    L = [?_assert(is_binary(dns_names:ercode_name(Number))) || Number <- Cases],
-    [?_assertEqual(undefined, dns_names:ercode_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:ercode_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_ercode(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:ercode_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_ercode(dns_names:ercode_name(N))) || N <- Cases].
 
 eoptcode_name_test_() ->
     Cases = [
@@ -164,8 +179,10 @@ eoptcode_name_test_() ->
         ?DNS_EOPTCODE_NSID_NUMBER,
         ?DNS_EOPTCODE_OWNER_NUMBER
     ],
-    L = [?_assert(is_binary(dns_names:eoptcode_name(Number))) || Number <- Cases],
-    [?_assertEqual(undefined, dns_names:eoptcode_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:eoptcode_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_eoptcode(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:eoptcode_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_eoptcode(dns_names:eoptcode_name(N))) || N <- Cases].
 
 llqopcode_name_test_() ->
     Cases = [
@@ -173,8 +190,10 @@ llqopcode_name_test_() ->
         ?DNS_LLQOPCODE_REFRESH_NUMBER,
         ?DNS_LLQOPCODE_EVENT_NUMBER
     ],
-    L = [?_assert(is_binary(dns_names:llqopcode_name(Number))) || Number <- Cases],
-    [?_assertEqual(undefined, dns_names:llqopcode_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:llqopcode_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_llqopcode(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:llqopcode_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_llqopcode(dns_names:llqopcode_name(N))) || N <- Cases].
 
 llqerrcode_name_test_() ->
     Cases = [
@@ -186,5 +205,7 @@ llqerrcode_name_test_() ->
         ?DNS_LLQERRCODE_BADVERS_NUMBER,
         ?DNS_LLQERRCODE_UNKNOWNERR_NUMBER
     ],
-    L = [?_assert(is_binary(dns_names:llqerrcode_name(Number))) || Number <- Cases],
-    [?_assertEqual(undefined, dns_names:llqerrcode_name(?UNKNOWN_INT)) | L].
+    [?_assertEqual(undefined, dns_names:llqerrcode_name(?UNKNOWN_INT))] ++
+        [?_assertEqual(undefined, dns_names:name_llqerrcode(?UNKNOWN_BIN))] ++
+        [?_assert(is_binary(dns_names:llqerrcode_name(N))) || N <- Cases] ++
+        [?_assertEqual(N, dns_names:name_llqerrcode(dns_names:llqerrcode_name(N))) || N <- Cases].

--- a/test/dns_test.erl
+++ b/test/dns_test.erl
@@ -548,6 +548,17 @@ encode_dname_4_test_() ->
     ],
     [?_assertEqual(Expect, Result) || {Expect, Result} <- Cases].
 
+dname_to_lower_labels_test_() ->
+    Cases = [
+        {<<>>, []},
+        {<<".">>, []},
+        {<<"A.B.C">>, [<<"a">>, <<"b">>, <<"c">>]},
+        {<<"A.B.C.">>, [<<"a">>, <<"b">>, <<"c">>]},
+        {<<"A\\.B.c">>, [<<"a.b">>, <<"c">>]},
+        {<<"A\\\\.b.C">>, [<<"a\\">>, <<"b">>, <<"c">>]}
+    ],
+    [?_assertEqual(Expect, dns:dname_to_lower_labels(Arg)) || {Arg, Expect} <- Cases].
+
 dname_to_labels_test_() ->
     Cases = [
         {<<>>, []},

--- a/test/dns_test.erl
+++ b/test/dns_test.erl
@@ -662,6 +662,28 @@ dns_case_insensitive_comparison_test_() ->
             dns:compare_dname(
                 dns:dname_to_upper(<<"example.com">>), dns:dname_to_lower(<<"EXAMPLE.COM">>)
             )
+        ),
+        ?_assert(dns:compare_labels([<<"example">>, <<"com">>], [<<"EXAMPLE">>, <<"COM">>])),
+        ?_assert(
+            dns:compare_labels([<<"www">>, <<"example">>, <<"com">>], [
+                <<"WWW">>, <<"example">>, <<"COM">>
+            ])
+        ),
+        ?_assert(
+            dns:compare_labels([<<"www">>, <<"EXAMPLE">>, <<"com">>], [
+                <<"WWW">>, <<"example">>, <<"COM">>
+            ])
+        ),
+        ?_assertNot(
+            dns:compare_labels([<<"www">>, <<"different">>, <<"com">>], [
+                <<"WWW">>, <<"example">>, <<"COM">>
+            ])
+        ),
+        ?_assertNot(
+            dns:compare_labels([<<"www">>, <<"example">>], [<<"www">>, <<"example">>, <<"com">>])
+        ),
+        ?_assertNot(
+            dns:compare_labels([<<"www">>, <<"example">>, <<"com">>], [<<"www">>, <<"example">>])
         )
     ].
 


### PR DESCRIPTION
Just basically syntactic sugar and minor helper functions that are used too often in erldns.