### PR TITLE
Surface malformed EDNS COOKIE as FORMERR instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v5.0.12
+
+### Fixed
+
+- A malformed EDNS COOKIE option (RFC 7873) in a received message now decodes to a `formerr` result instead of raising `bad_cookie`.
+
 ## v5.0.11
 
 ### Fixed

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -299,31 +299,44 @@ do_decode_message_additional(_MsgBin, DataBin, 0, RRs) ->
 do_decode_message_additional(_MsgBin, <<>>, _Count, RRs) ->
     {truncated, lists:reverse(RRs), <<>>};
 do_decode_message_additional(MsgBin, DataBin, Count, RRs) ->
-    try dns_domain:from_wire(MsgBin, DataBin) of
-        {<<>>,
-            <<?DNS_TYPE_OPT:16/unsigned, UPS:16/unsigned, ExtRcode:8, Version:8, DNSSEC:1, _Z:15,
-                EDataLen:16, EDataBin:EDataLen/binary, RemBin/binary>>} ->
-            Data = decode_optrrdata(EDataBin),
-            RR = #dns_optrr{
-                udp_payload_size = UPS,
-                ext_rcode = ExtRcode,
-                version = Version,
-                dnssec = decode_bool(DNSSEC),
-                data = Data
-            },
-            do_decode_message_additional(MsgBin, RemBin, Count - 1, [RR | RRs]);
-        {Name,
-            <<Type:16/unsigned, Class:16/unsigned, TTL:32/signed, Len:16, RdataBin:Len/binary,
-                RemBin/binary>>} ->
-            RR = #dns_rr{
-                name = Name,
-                type = Type,
-                class = Class,
-                ttl = TTL,
-                data = decode_rrdata(MsgBin, Class, Type, RdataBin)
-            },
-            do_decode_message_additional(MsgBin, RemBin, Count - 1, [RR | RRs]);
-        {_Name, _Bin} ->
+    %% The record parse is the `try` protected expression so a malformed rdata — e.g. a bad EDNS
+    %% COOKIE (RFC 7873), which raises `bad_cookie` — surfaces as a decode-error tuple instead of
+    %% escaping. The recursion stays in the `of` body to remain in tail position.
+    try
+        case dns_domain:from_wire(MsgBin, DataBin) of
+            {<<>>,
+                <<?DNS_TYPE_OPT:16/unsigned, UPS:16/unsigned, ExtRcode:8, Version:8, DNSSEC:1,
+                    _Z:15, EDataLen:16, EDataBin:EDataLen/binary, RemBin/binary>>} ->
+                {
+                    #dns_optrr{
+                        udp_payload_size = UPS,
+                        ext_rcode = ExtRcode,
+                        version = Version,
+                        dnssec = decode_bool(DNSSEC),
+                        data = decode_optrrdata(EDataBin)
+                    },
+                    RemBin
+                };
+            {Name,
+                <<Type:16/unsigned, Class:16/unsigned, TTL:32/signed, Len:16, RdataBin:Len/binary,
+                    RemBin/binary>>} ->
+                {
+                    #dns_rr{
+                        name = Name,
+                        type = Type,
+                        class = Class,
+                        ttl = TTL,
+                        data = decode_rrdata(MsgBin, Class, Type, RdataBin)
+                    },
+                    RemBin
+                };
+            {_Name, _Bin} ->
+                truncated
+        end
+    of
+        {RR, Rest} ->
+            do_decode_message_additional(MsgBin, Rest, Count - 1, [RR | RRs]);
+        truncated ->
             {truncated, lists:reverse(RRs), DataBin}
     catch
         Error when is_atom(Error) ->
@@ -346,19 +359,31 @@ do_decode_message_body(_MsgBin, DataBin, 0, RRs) ->
 do_decode_message_body(_MsgBin, <<>>, _Count, RRs) ->
     {truncated, lists:reverse(RRs), <<>>};
 do_decode_message_body(MsgBin, DataBin, Count, RRs) ->
-    try dns_domain:from_wire(MsgBin, DataBin) of
-        {Name,
-            <<Type:16/unsigned, Class:16/unsigned, TTL:32/signed, Len:16, RdataBin:Len/binary,
-                RemBin/binary>>} ->
-            RR = #dns_rr{
-                name = Name,
-                type = Type,
-                class = Class,
-                ttl = TTL,
-                data = decode_rrdata(MsgBin, Class, Type, RdataBin)
-            },
-            do_decode_message_body(MsgBin, RemBin, Count - 1, [RR | RRs]);
-        {_Name, _Bin} ->
+    %% As in `do_decode_message_additional/4`: the parse is the protected expression so a failure
+    %% decoding an RR's rdata (e.g. a bad compression pointer reached via `from_wire/2`) surfaces
+    %% as a decode-error tuple, while the recursion stays in the `of` body (tail position).
+    try
+        case dns_domain:from_wire(MsgBin, DataBin) of
+            {Name,
+                <<Type:16/unsigned, Class:16/unsigned, TTL:32/signed, Len:16, RdataBin:Len/binary,
+                    RemBin/binary>>} ->
+                {
+                    #dns_rr{
+                        name = Name,
+                        type = Type,
+                        class = Class,
+                        ttl = TTL,
+                        data = decode_rrdata(MsgBin, Class, Type, RdataBin)
+                    },
+                    RemBin
+                };
+            {_Name, _Bin} ->
+                truncated
+        end
+    of
+        {RR, Rest} ->
+            do_decode_message_body(MsgBin, Rest, Count - 1, [RR | RRs]);
+        truncated ->
             {truncated, lists:reverse(RRs), DataBin}
     catch
         Error when is_atom(Error) ->

--- a/test/dns_cookie_SUITE.erl
+++ b/test/dns_cookie_SUITE.erl
@@ -91,7 +91,8 @@ error_encode_too_small(_) ->
         <<66, 248, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111,
             109, 0, 0, 1, 0, 1, 0, 0, 41, 16, 0, 0, 0, 0, 0, 0, 9, 0, 10, 0, 5, 115, 109, 97, 108,
             108>>,
-    ?assertError(bad_cookie, dns:decode_message(TooSmallCookie)).
+    %% RFC 7873: a malformed COOKIE is a format error, surfaced as a FORMERR decode result.
+    ?assertMatch({formerr, _, _}, dns:decode_message(TooSmallCookie)).
 
 error_encode_bad_msg(_) ->
     Query = #dns_query{name = ~"example.com", type = ?DNS_TYPE_A},
@@ -343,7 +344,7 @@ malformed_wire_cookie_no_data(_) ->
         0,
         0
     >>,
-    ?assertError(bad_cookie, dns:decode_message(BadBin)).
+    ?assertMatch({formerr, _, _}, dns:decode_message(BadBin)).
 
 malformed_wire_cookie_insufficient_data(_) ->
     BadBin = <<
@@ -402,7 +403,7 @@ malformed_wire_cookie_insufficient_data(_) ->
         % 5 bytes (invalid!)
         "small"
     >>,
-    ?assertError(bad_cookie, dns:decode_message(BadBin)).
+    ?assertMatch({formerr, _, _}, dns:decode_message(BadBin)).
 
 boundary_server_cookie_minimum(_) ->
     boundary_server_cookie_test_valid(?FUNCTION_NAME, ~"12345678").


### PR DESCRIPTION
A COOKIE option (RFC 7873) with an invalid length raises `bad_cookie` in `do_decode_optrrdata/2`. That call sat in the `of` body of the per-record `try ... of ... catch` in `do_decode_message_additional/4`, where exceptions are not caught, so it escaped `dns_decode`'s own error handling and propagated to the caller's decode loop as an uncaught crash.

Move the record parse (the `from_wire/2` decode plus the rdata decoders `decode_optrrdata/1` and `decode_rrdata/4`) into the `try` protected expression so any decode failure on untrusted wire data — a bad cookie, or a bad compression pointer in an RR's rdata — surfaces as a `{formerr, _, _}` decode-error tuple. The recursion stays in the `of` body to remain in tail position. The same shape is applied to `do_decode_message_body/4`.

Encoding an invalid cookie remains a hard error: building such a message is a programming error on our side.