### PR TITLE
Reject NOTIFY with invalid counts instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v5.0.13
+
+### Fixed
+
+- Correctly return `formerr` on invalid NOTIFY DNS messages (rfc1996 §3.7: a NOTIFY carries exactly one question (QDCOUNT=1) and at most one), (#130)
+
 ## v5.0.12
 
 ### Fixed

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -74,6 +74,12 @@ decode_query(
                 Id, QR, OC, AA, TC, RD, RA, AD, CD, RC, QC, ANC, AUC, ADC
             ),
             decode_body(MsgBin, Rest0, Msg0);
+        %% NOTIFY (opcode 4) with invalid counts - reject with FORMERR
+        %% rfc1996 §3.7: a NOTIFY carries exactly one question (QDCOUNT=1) and at most one
+        %% SOA in the authority section. Anything else (e.g. QDCOUNT > 1 from malformed
+        %% traffic) must be rejected rather than fall through the case and crash.
+        {0, 0, ?DNS_OPCODE_NOTIFY, _, _, _, _} ->
+            {formerr, undefined, MsgBin};
         %% UPDATE (opcode 5) - rfc2136
         %% Expected: QR=0, TC=0, QC=1 (ZONE section), ANC>=0 (PREREQ section),
         %%   AUC>=0 (UPDATE section)

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -107,6 +107,7 @@ groups() ->
             decode_query_nscount_rejected,
             decode_query_qdcount_invalid,
             decode_query_notify_allowed,
+            decode_query_notify_invalid_counts,
             decode_query_update_allowed,
             decode_query_too_short,
             decode_query_iquery_notimp,
@@ -1254,6 +1255,22 @@ decode_query_notify_allowed(_) ->
     Encoded = dns:encode_message(Msg),
     Decoded = dns:decode_query(Encoded),
     ?assertMatch(#dns_message{oc = 4, anc = 1, auc = 1}, Decoded).
+
+decode_query_notify_invalid_counts(_) ->
+    %% NOTIFY (opcode 4) with QDCOUNT > 1 must be rejected as FORMERR, not crash.
+    %% Regression for a case_clause seen on malformed traffic: {0,0,4,256,1,0,0}.
+    QName = <<"example.com">>,
+    Query = #dns_query{name = QName, type = ?DNS_TYPE_SOA},
+    Msg = #dns_message{qc = 1, oc = ?DNS_OPCODE_NOTIFY, questions = [Query]},
+    Encoded = dns:encode_message(Msg),
+    %% Rewrite the header to advertise QDCOUNT=256 while keeping the single question body.
+    <<Id:16, QR:1, OC:4, AA:1, TC:1, RD:1, RA:1, Z:1, AD:1, CD:1, RC:4, _QC:16, ANC:16, AUC:16,
+        ADC:16, Rest/binary>> = Encoded,
+    ModifiedHeader =
+        <<Id:16, QR:1, OC:4, AA:1, TC:1, RD:1, RA:1, Z:1, AD:1, CD:1, RC:4, 256:16, ANC:16, AUC:16,
+            ADC:16>>,
+    ModifiedBin = <<ModifiedHeader/binary, Rest/binary>>,
+    ?assertMatch({formerr, undefined, _}, dns:decode_query(ModifiedBin)).
 
 decode_query_update_allowed(_) ->
     %% UPDATE (opcode 5) should be allowed even with Answer/Authority records


### PR DESCRIPTION
decode_query/1 only handled NOTIFY (opcode 4) with QDCOUNT=1. A NOTIFY with any other question count (e.g. QDCOUNT=256 from malformed traffic) matched no case clause and raised case_clause, e.g. {case_clause, {0,0,4,256,1,0,0}} for {QR,TC,OC,QC,ANC,AUC,ADC}.

Add a NOTIFY catch-all that returns formerr, mirroring the existing QUERY/UPDATE handling, so the case is total. Adds a regression test covering the exact header from the observed crash.