### PR TITLE
Fix additional-section name compression for non-EDNS responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+### Fixed
+
+- Correct name compression in the additional section of `encode_message/2` for non-EDNS responses
+
 ## v5.0.13
 
 ### Fixed

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -172,7 +172,7 @@ encode_message_default(
             BodySize = byte_size(Body),
             {OptRRBin, Ad0} = encode_message_pop_optrr(Additional),
             OptRRBinSize = byte_size(OptRRBin),
-            Pos2 = BodySize,
+            Pos2 = ?HEADER_SIZE + BodySize,
             #dns_message{anc = ANC, auc = AUC} = Msg0,
             case SpaceLeft1 + PreservedOptRRBinSize - BodySize of
                 SpaceLeft2 when SpaceLeft2 < OptRRBinSize ->

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -34,7 +34,8 @@ groups() ->
             encode_message_max_size,
             encode_message_invalid_size,
             truncated_query_enforces_opt_record,
-            encode_default_message_question_offset_correct
+            encode_default_message_question_offset_correct,
+            encode_default_message_additional_offset_correct
         ]},
         {txt_records, [parallel], [
             long_txt,
@@ -308,6 +309,58 @@ encode_default_message_question_offset_correct(_) ->
             answers = [#dns_rr{name = QName}],
             authority = [#dns_rr{name = QName}],
             additional = [#dns_rr{name = QName}]
+        },
+        Decoded
+    ).
+
+encode_default_message_additional_offset_correct(_) ->
+    QName = <<"example.com">>,
+    MailName = <<"mail.example.com">>,
+    Question = #dns_query{name = QName, type = ?DNS_TYPE_MX},
+    %% The MX answer introduces MailName earlier in the message.
+    Answer = #dns_rr{
+        name = QName,
+        type = ?DNS_TYPE_MX,
+        ttl = 3600,
+        data = #dns_rrdata_mx{preference = 10, exchange = MailName}
+    },
+    %% Two additional (glue) records sharing the same owner name. Unlike
+    %% encode_default_message_question_offset_correct (which has a single
+    %% additional record), this exercises name compression *within* the
+    %% additional section, where the section start position matters.
+    AddA = #dns_rr{
+        name = MailName,
+        type = ?DNS_TYPE_A,
+        ttl = 3600,
+        data = #dns_rrdata_a{ip = {1, 2, 3, 4}}
+    },
+    AddAAAA = #dns_rr{
+        name = MailName,
+        type = ?DNS_TYPE_AAAA,
+        ttl = 3600,
+        data = #dns_rrdata_aaaa{ip = {0, 0, 0, 0, 0, 0, 0, 1}}
+    },
+    Msg = #dns_message{
+        qc = 1,
+        anc = 1,
+        auc = 0,
+        adc = 2,
+        questions = [Question],
+        answers = [Answer],
+        additional = [AddA, AddAAAA]
+    },
+    %% encode_message/2 uses encode_message_default/2, which positions the
+    %% additional section at Pos2 = BodySize -- omitting the 12-byte header.
+    %% The additional-section names are therefore registered 12 bytes too low,
+    %% so the AAAA owner-name emits a compression pointer into the middle of an
+    %% earlier record and the message fails to decode ({formerr, ...}).
+    Encoded = dns:encode_message(Msg, #{max_size => 512}),
+    Decoded = dns:decode_message(Encoded),
+    ?assertEqual(Msg, Decoded),
+    ?assertMatch(
+        #dns_message{
+            answers = [#dns_rr{name = QName}],
+            additional = [#dns_rr{name = MailName}, #dns_rr{name = MailName}]
         },
         Decoded
     ).


### PR DESCRIPTION
### Disclaimer
Thanks for maintaining `dnsimple` and `dns_erlang`, and for taking the time to review this PR!

1. I have read the [CONTRIBUTING.md](https://github.com/dnsimple/dns_erlang/blob/main/CONTRIBUTING.md) guide;
2. I have limited experience working with Erlang/OTP, feel free to point out anything that isn't idiomatic;
3. I tested the changes locally with **Erlang/OTP 27** (erts 15.2.7.10, using the official `erlang:27` Docker image);
4. I'll be happy to provide additional information, adjust the PR, tests, or changelog; just let me know :+1: 

---

### Issue and context

One of my customers experiences mail delivery failures to a recipient whose DNS zone is hosted on DNSimple, and for which the `MX` responses are rejected by strict resolvers / clients when EDNS is disabled.

The error is reported as:

- `Got bad packet: bad label type` (via `dig +noedns @ns3.dnsimple.com MX <recipient domain>`);
- `Invalid Name at offset 72! (name truncated?)` (via `nslookup`);
- `Malformed Packet (Exception occurred)` when inspecting DNS response packets captured with `tcpdump`.

After investigating the contents of the DNS zone and comparing the contents of the responses (with and without EDNS), it appears that:

- the response carries `A` + `AAAA` glue for the mail host;
- `dns_erlang` encodes those two additional records such that the `AAAA` owner-name is a compression pointer into the middle of an earlier record.

The same packet round-trips as a failure in `dns_erlang` itself:
`dns:decode_message(dns:encode_message(Msg, #{}))` returns `{formerr, _, _}`.

### Diagnostics

:warning: **The diagnostics below are anonymized**

- Customer information (sender and recipient domains, IP addresses) has been redacted and replaced with dummy domains and IPv4/IPv6 addresses (`example.com`, RFC 5737/3849 documentation addresses);
- DNSimple identifiers and the wire structure are preserved verbatim.

_If need be, I can provide any relevant information (recipient domain, command output, packet capture) privately over email if you'd like to compare their output against production._

**Zone records** (served by DNSimple):

```
example.com.        3600  IN  SOA   ns1.dnsimple.com. admin.dnsimple.com. <serial> 86400 7200 604800 300
example.com.        3600  IN  NS    ns1.dnsimple.com.
example.com.        3600  IN  NS    ns2.dnsimple-edge.net.
example.com.        3600  IN  NS    ns3.dnsimple.com.
example.com.        3600  IN  NS    ns4.dnsimple-edge.org.
example.com.         600  IN  MX    10 mail.example.com.
mail.example.com.    600  IN  A     192.0.2.1
mail.example.com.    600  IN  AAAA  2001:db8::1
```

**`dig` — non-EDNS query is rejected, EDNS query is fine:**

```shell
$ dig +norecurse +noedns @ns1.dnsimple.com example.com MX
;; Got bad packet: bad label type

$ dig +norecurse @ns1.dnsimple.com example.com MX
;; flags: qr aa; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 3
example.com.        600  IN  MX    10 mail.example.com.
mail.example.com.   600  IN  A     192.0.2.1
mail.example.com.   600  IN  AAAA  2001:db8::1
```

**`nslookup` (non-EDNS) also fails:**

```shell
$ nslookup -type=mx -norecurse example.com ns1.dnsimple.com
;; Got bad packet: bad label type
```

**The malformed response on the wire** (99-byte DNS payload; L2/L3 wrapping omitted):

```
0000  61 1b 84 00 00 01 00 01 00 00 00 02 07 65 78 61   question: example
0010  6d 70 6c 65 03 63 6f 6d 00 00 0f 00 01 c0 0c 00   .com .. MX ..
0020  0f 00 01 00 00 02 58 00 09 00 0a 04 6d 61 69 6c   answer MX 10 "mail"
0030  c0 0c 04 6d 61 69 6c c0 0c 00 01 00 01 00 00 02   ..  add#1 A "mail" ..
0040  58 00 04 c0 00 02 01 c0 26 00 1c 00 01 00 00 02   .. 192.0.2.1  add#2 AAAA name=c0 26
0050  58 00 10 20 01 0d b8 00 00 00 00 00 00 00 00 00   .. 2001:db8::1
0060  00 00 01
```

The additional `AAAA` owner-name is `c0 26` at offset `0x26` (38), which is inside
the MX record's TTL field (an invalid label type), not a valid name.

**tshark verdict on the RAW payload:**

```
Standard query response 0x611b MX example.com MX 10 mail.example.com A 192.0.2.1[Malformed Packet]
  Answer RRs: 1
  Additional RRs: 2
    example.com: type MX, class IN, preference 10, mx mail.example.com
  Additional records
    Address: 192.0.2.1
  [Malformed Packet: DNS]
    [Expert Info (Error/Malformed): Malformed Packet (Exception occurred)]
```

### Root cause

In `encode_message_default/2`:

- the question/answer/authority sections are positioned with `Pos1 = ?HEADER_SIZE + Acc1Size`;
- the additional section start is `Pos2 = BodySize`;
- `Body` has the 12-byte header stripped.

Every additional-section name is therefore registered 12 bytes too low, so a second
record reusing that name emits a pointer to an invalid position.

Using EDNS masks the issue: the `OPT` record shifts the position past the earlier occurrence
of the name, so the correct pointer is reused.

---

### Changes
This PR provides:

- a unitary test to reproduce the issue against a DNS zone containing two additional records;
- a fix for the issue;
- a changelog entry for the fix.

### Edits
- 2026-07-21 08:46:06+00:00 UTC - Amend the commit with a verified PGP signature
- 2026-07-21 09:24:14+00:00 UTC - Amend the commit to ensure both author and committer emails exactly match the PGP signature
- 2026-07-21 11:55:39+00:00 UTC - Open PR against the compliance testing app: https://github.com/dnsimple/dnstest/pull/48
