### PR TITLE
Optimize dns_domain:to_wire/3 name encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v5.0.14
+
+### Changed
+
+- Optimized `dns_domain:to_wire/3` (compressed name encoding): 1.4–2.8x faster on typical names, up to 17–22x on many-label names such as IPv6 reverse PTRs, with 1.1–3x less allocation.
+
 ## v5.0.13
 
 ### Fixed

--- a/src/dns_domain.erl
+++ b/src/dns_domain.erl
@@ -367,32 +367,115 @@ Use this when encoding DNS messages where multiple names may share suffixes
 """.
 -spec to_wire(compmap(), non_neg_integer(), dname()) -> {wire(), compmap()}.
 to_wire(CompMap, Pos, Name) when is_binary(Name) ->
-    Labels = do_split(Name, <<>>),
-    LowerLabels = do_split(to_lower_chunk(Name, <<>>), <<>>),
-    to_wire_labels_compressed(CompMap, Pos, Labels, LowerLabels, <<>>).
+    {Labels, LowerLabels} = to_wire_prep(Name),
+    to_wire_labels_compressed(CompMap, Pos, Labels, LowerLabels, <<>>, []).
 
-to_wire_labels_compressed(_, _, [], [], Acc) when 255 < byte_size(Acc) ->
-    error(name_too_long);
-to_wire_labels_compressed(CompMap, _Pos, [], [], Acc) ->
-    {<<Acc/binary, 0>>, CompMap};
-to_wire_labels_compressed(_, _, [L | _], [_ | _] = _, _) when 63 < byte_size(L) ->
-    error({label_too_long, L});
-to_wire_labels_compressed(CompMap, Pos, [L | Ls], [_ | LwrLs] = LwrLabels, Acc) ->
-    case maps:get(LwrLabels, CompMap, undefined) of
-        %% Compression pointer must point to prior occurrence
-        Ptr when is_integer(Ptr), Ptr < Pos ->
-            {<<Acc/binary, 3:2, Ptr:14>>, CompMap};
+%% Label preparation: returns {Labels, LowerLabels}, where both are the same term when the name
+%% needs no lowering (the common case). Note also that label offsets are case-invariant.
+%%
+%% to_lower/1 is a strict byte-for-byte map that never touches $. or $\\ and
+%% never produces them, so label offsets are case-invariant: the name never
+%% needs to be split twice. When the name contains no backslash, labels are
+%% sub-binaries produced by binary:split/3, a trailing dot is trimmed up
+%% front (with no backslash it cannot be an escaped dot) so no trailing
+%% empty part can occur, and mixed-case names lower the trimmed name once
+%% and split it again — guaranteed to yield the structure of the already
+%% validated Labels. Escaped names fall back to the copying do_split/2.
+to_wire_prep(Name) ->
+    {DotPat, BslashPat} = compiled_patterns(),
+    case binary:match(Name, BslashPat) of
+        nomatch ->
+            Trimmed = trim_dot(Name),
+            Labels = validate(binary:split(Trimmed, DotPat, [global])),
+            case has_upper(Trimmed) of
+                false ->
+                    {Labels, Labels};
+                true ->
+                    Lower = to_lower_chunk(Trimmed, <<>>),
+                    {Labels, binary:split(Lower, DotPat, [global])}
+            end;
         _ ->
-            NewCompMap =
-                case Pos < (1 bsl 14) of
-                    true -> CompMap#{LwrLabels => Pos};
-                    false -> CompMap
-                end,
-            Len = byte_size(L),
-            NewPos = Pos + 1 + Len,
-            NewAcc = <<Acc/binary, Len, L/binary>>,
-            to_wire_labels_compressed(NewCompMap, NewPos, Ls, LwrLs, NewAcc)
+            Labels = do_split(Name, <<>>),
+            case has_upper(Name) of
+                false -> {Labels, Labels};
+                true -> {Labels, [to_lower_chunk(L, <<>>) || L <- Labels]}
+            end
     end.
+
+compiled_patterns() ->
+    case persistent_term:get({?MODULE, patterns}, undefined) of
+        undefined ->
+            Pats = {binary:compile_pattern(<<$.>>), binary:compile_pattern(<<$\\>>)},
+            persistent_term:put({?MODULE, patterns}, Pats),
+            Pats;
+        Pats ->
+            Pats
+    end.
+
+%% Drop one trailing dot (FQDN form) so binary:split cannot produce a trailing empty part.
+trim_dot(<<>>) ->
+    <<>>;
+trim_dot(Name) ->
+    Sz = byte_size(Name) - 1,
+    case Name of
+        <<Trimmed:Sz/binary, $.>> -> Trimmed;
+        _ -> Name
+    end.
+
+%% Enforce do_split's semantics on the split parts, position-ordered: a leading empty label is
+%% tolerated (historical quirk: ".foo"), any other empty label raises empty_label, and labels are
+%% limited to 63 bytes.
+validate([<<>>]) ->
+    %% "" and "." both reduce to this
+    [];
+validate([First | Rest] = Parts) when byte_size(First) =< 63 ->
+    validate_rest(Rest),
+    Parts;
+validate([First | _]) ->
+    error({label_too_long, First}).
+
+validate_rest([]) ->
+    ok;
+validate_rest([<<>> | _]) ->
+    error({invalid_dname, empty_label});
+validate_rest([L | _]) when 63 < byte_size(L) ->
+    error({label_too_long, L});
+validate_rest([_ | Rest]) ->
+    validate_rest(Rest).
+
+to_wire_labels_compressed(_, _, [], [], Acc, _) when 255 < byte_size(Acc) ->
+    error(name_too_long);
+to_wire_labels_compressed(CompMap, _Pos, [], [], Acc, Pending) ->
+    {<<Acc/binary, 0>>, merge_pending(CompMap, Pending)};
+to_wire_labels_compressed(CompMap, Pos, [L | Ls], [_ | LwrLs] = LwrLabels, Acc, Pending) ->
+    case CompMap of
+        %% Compression pointer must point to prior occurrence
+        #{LwrLabels := Ptr} when is_integer(Ptr), Ptr < Pos ->
+            {<<Acc/binary, 3:2, Ptr:14>>, merge_pending(CompMap, Pending)};
+        _ ->
+            Len = byte_size(L),
+            63 < Len andalso error({label_too_long, L}),
+            NewPending =
+                case Pos < (1 bsl 14) of
+                    true -> [{LwrLabels, Pos} | Pending];
+                    false -> Pending
+                end,
+            NewAcc = <<Acc/binary, Len, L/binary>>,
+            to_wire_labels_compressed(CompMap, Pos + 1 + Len, Ls, LwrLs, NewAcc, NewPending)
+    end.
+
+%% Suffix keys of the name being encoded can never be looked up while encoding that same name
+%% (suffixes strictly shrink), so this is observably identical while avoiding one map copy per label
+merge_pending(CompMap, []) ->
+    CompMap;
+merge_pending(CompMap, [{K, P}]) ->
+    CompMap#{K => P};
+merge_pending(CompMap, [{K1, P1}, {K2, P2}]) ->
+    CompMap#{K1 => P1, K2 => P2};
+merge_pending(CompMap, [{K1, P1}, {K2, P2}, {K3, P3}]) ->
+    CompMap#{K1 => P1, K2 => P2, K3 => P3};
+merge_pending(CompMap, Pending) ->
+    maps:merge(CompMap, maps:from_list(Pending)).
 
 -doc """
 Convert wire format to domain name.
@@ -623,7 +706,11 @@ Returns provided name with case-insensitive characters in uppercase.
 to_upper(Data) when is_binary(Data) ->
     to_upper_chunk(Data, <<>>).
 
--compile({inline, [lower_word56/1, upper_word56/1, lower_byte/1, upper_byte/1, are_equal_ci/2]}).
+-compile(
+    {inline, [
+        lower_word56/1, upper_word56/1, lower_byte/1, upper_byte/1, are_equal_ci/2, has_upper_word/1
+    ]}
+).
 
 %% 56-bit (7-byte) SWAR constants — stays within BEAM small integer range
 %% (60-bit on 64-bit systems), avoiding bignum allocation.
@@ -648,6 +735,22 @@ upper_word56(W) ->
     GeA = ((W bor ?HIGHS56) - (?ONES56 * $a)) band ?HIGHS56,
     GeZ1 = ((W bor ?HIGHS56) - (?ONES56 * ($z + 1))) band ?HIGHS56,
     W bxor (((GeA bxor GeZ1) band AsciiMask) bsr 2).
+
+%% SWAR scan for any byte in [$A, $Z], 7 bytes at a time.
+-spec has_upper(binary()) -> boolean().
+has_upper(<<W:56/unsigned-little, Rest/binary>>) ->
+    has_upper_word(W) orelse has_upper(Rest);
+has_upper(<<C, Rest/binary>>) ->
+    ($A =< C andalso C =< $Z) orelse has_upper(Rest);
+has_upper(<<>>) ->
+    false.
+
+-spec has_upper_word(non_neg_integer()) -> boolean().
+has_upper_word(W) ->
+    AsciiMask = (W band ?HIGHS56) bxor ?HIGHS56,
+    GeA = ((W bor ?HIGHS56) - (?ONES56 * $A)) band ?HIGHS56,
+    GeZ1 = ((W bor ?HIGHS56) - (?ONES56 * ($Z + 1))) band ?HIGHS56,
+    (GeA band (bnot GeZ1) band AsciiMask) =/= 0.
 
 upper_byte(X) ->
     element(


### PR DESCRIPTION
The compressed name encoder previously split every name twice: once raw, and once after lowering a full copy of the name for the compression-map keys. Since to_lower/1 is a strict byte-for-byte map that never touches '.' or '\' (and never produces them), label offsets are case-invariant and the second split was redundant. The encoder now:

- splits the name once; for names without backslashes (the common case) labels are zero-copy sub-binaries produced by binary:split/3, with a trailing dot trimmed up front so no trailing-empty handling is needed (compiled patterns are cached in a persistent_term);
- skips lowering entirely when the name is already lowercase, reusing the labels list itself as the compression-map keys (zero extra allocation);
- for mixed-case names (0x20-randomized qnames), lowers the trimmed name once and re-splits it, which is guaranteed to reproduce the structure of the already-validated labels;
- falls back to the copying do_split/2 for names containing escape sequences;
- defers compression-map suffix inserts and applies them in one batch on exit. Suffix keys of the name being encoded can never be looked up while encoding that same name, so this is observably identical, while avoiding one map copy per label and the term-ordered key comparisons that incremental flatmap inserts perform against deep-sharing suffix-list keys (the source of a pathological slowdown on many-label names such as IPv6 reverse PTRs).

Behavior is unchanged, including raised error terms and the historical leading-empty-label quirk (".foo"). This was verified by a parity harness comparing old and new implementations across 31 names (case-randomized, escaped, FQDN, over-long, contiguous-dot, >255-octet) x 5 compression-map states (cold, warm, Pos >= 2^14, stale pointers), matching both return values and raised exceptions, run on both machines below. make test (lint, xref, dialyzer, ct, cover) passes.

Benchmarks (Benchee, Erlang/OTP 29.0.3, JIT enabled, end-to-end to_wire/3, average time before -> after):

Apple M4 Pro (macOS):

```
  input                       before      after       speedup
  lc 2-label, cold map        384 ns      213 ns      1.80x
  lc 3-label, cold map        527 ns      266 ns      1.98x
  0x20 3-label, cold map      532 ns      444 ns      1.20x
  lc 8-label, cold map        1.51 us     0.54 us     2.82x
  0x20 8-label, cold map      1.52 us     0.75 us     2.03x
  suffix hit, warm map        640 ns      380 ns      1.68x
  full hit, warm map          496 ns      244 ns      2.03x
  trailing dot, cold map      554 ns      278 ns      2.00x
  escaped label, cold map     565 ns      331 ns      1.71x
  63B label, cold map         540 ns      253 ns      2.14x
  reverse PTR v4, cold map    1.17 us     0.53 us     2.21x
  SRV underscores, cold map   702 ns      410 ns      1.71x
  50x 1-char labels, cold     211.3 us    9.4 us      22.60x
  batch of 12 zone names      7.60 us     4.62 us     1.64x
```

AMD Ryzen 9 9950X3D (Linux):

```
  input                       before      after       speedup
  lc 2-label, cold map        470 ns      320 ns      1.47x
  lc 3-label, cold map        591 ns      393 ns      1.51x
  0x20 3-label, cold map      594 ns      556 ns      1.07x
  lc 8-label, cold map        1.50 us     0.66 us     2.28x
  0x20 8-label, cold map      1.50 us     0.83 us     1.82x
  suffix hit, warm map        673 ns      471 ns      1.43x
  full hit, warm map          521 ns      307 ns      1.69x
  trailing dot, cold map      607 ns      394 ns      1.54x
  escaped label, cold map     628 ns      415 ns      1.51x
  63B label, cold map         628 ns      344 ns      1.82x
  reverse PTR v4, cold map    1.17 us     0.60 us     1.93x
  SRV underscores, cold map   737 ns      504 ns      1.46x
  50x 1-char labels, cold     147.3 us    8.5 us      17.29x
  batch of 12 zone names      7.87 us     5.02 us     1.57x
```

Memory usage and reduction counts were identical on both machines (reductions on the last two inputs differed by <3% between machines):

```
  input                       memory before -> after   reductions
  lc 2-label, cold map        712 B   -> 504 B         30  -> 26
  lc 3-label, cold map        960 B   -> 672 B         37  -> 26
  0x20 3-label, cold map      960 B   -> 896 B         37  -> 30
  lc 8-label, cold map        1.63 KB -> 1.04 KB       93  -> 48
  0x20 8-label, cold map      1.63 KB -> 1.46 KB       93  -> 53
  suffix hit, warm map        936 B   -> 568 B         66  -> 24
  full hit, warm map          752 B   -> 344 B         65  -> 23
  trailing dot, cold map      960 B   -> 672 B         38  -> 26
  escaped label, cold map     960 B   -> 784 B         40  -> 33
  63B label, cold map         712 B   -> 568 B         52  -> 34
  reverse PTR v4, cold map    1.63 KB -> 0.82 KB       65  -> 36
  SRV underscores, cold map   1.20 KB -> 0.63 KB       42  -> 30
  50x 1-char labels, cold     8.70 KB -> 2.82 KB       628 -> 245
  batch of 12 zone names      10.70 KB -> 6.48 KB      547 -> 375
```

Label-prep in isolation ({Labels, LowerLabels} construction, speedup M4 Pro / Ryzen): lc 3-label 2.40x/2.10x, 0x20 3-label 1.28x/1.17x, lc 8-label 3.91x/3.54x, 0x20 8-label 1.71x/1.83x, 63B label 2.47x/2.25x, trailing dot 2.58x/2.14x, 50x 1-char labels 6.02x/6.35x. The one known regression is prep for names combining escapes AND uppercase (0.88x/0.82x, a wasted binary:match before the fallback); end-to-end even the escaped inputs are 1.5-1.7x faster.

Claude Fable 5 helped with this.