### PR TITLE
Optimize dns_domain:from_wire/1,2 name decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Optimized `dns_domain:to_wire/3` (compressed name encoding): 1.4–2.8x faster on typical names, up to 17–22x on many-label names such as IPv6 reverse PTRs, with 1.1–3x less allocation.
+- Optimized `dns_domain:from_wire/1,2` (wire-format name decoding): ~1.1–1.2x faster on typical compressed names, up to 1.4–1.5x on pointer chains, with up to 18% less allocation on pointer-heavy names.
 
 ### Fixed
 

--- a/src/dns_domain.erl
+++ b/src/dns_domain.erl
@@ -477,6 +477,30 @@ merge_pending(CompMap, [{K1, P1}, {K2, P2}, {K3, P3}]) ->
 merge_pending(CompMap, Pending) ->
     maps:merge(CompMap, maps:from_list(Pending)).
 
+%% 56-bit (7-byte) and 32-bit SWAR constants — stay within BEAM small integer range
+-define(ONES56, 16#01010101010101).
+-define(HIGHS56, 16#80808080808080).
+-define(ONES32, 16#01010101).
+-define(HIGHS32, 16#80808080).
+-define(DOTS56, (?ONES56 * $.)).
+-define(BSLS56, (?ONES56 * $\\)).
+-define(DOTS32, (?ONES32 * $.)).
+-define(BSLS32, (?ONES32 * $\\)).
+
+%% Guard-legal test that a word contains neither '.' nor '\': W bxor (C *
+%% ones) has a zero byte iff W contains byte C, and (V - ones) band (bnot V)
+%% band highs =/= 0 iff V has a zero byte (exact, no false positives).
+-define(CLEAN56(W),
+    (0 =:=
+        ((((((W) bxor ?DOTS56) - ?ONES56) band bnot ((W) bxor ?DOTS56)) bor
+            ((((W) bxor ?BSLS56) - ?ONES56) band bnot ((W) bxor ?BSLS56))) band ?HIGHS56))
+).
+-define(CLEAN32(W),
+    (0 =:=
+        ((((((W) bxor ?DOTS32) - ?ONES32) band bnot ((W) bxor ?DOTS32)) bor
+            ((((W) bxor ?BSLS32) - ?ONES32) band bnot ((W) bxor ?BSLS32))) band ?HIGHS32))
+).
+
 -doc """
 Convert wire format to domain name.
 
@@ -519,7 +543,7 @@ from_wire_first(<<Len, _/binary>>) when Len > 63 ->
 from_wire_first(<<Len, Rest/binary>>) when byte_size(Rest) < Len ->
     error(truncated);
 from_wire_first(<<Len, Label:Len/binary, Rest/binary>>) ->
-    Acc = escape_label_inline(Label, <<>>),
+    Acc = escape_label_chunk(Label, <<>>),
     from_wire_rest(Rest, Acc, 1).
 
 from_wire_rest(_, Acc, _) when byte_size(Acc) > 255 ->
@@ -536,59 +560,22 @@ from_wire_rest(<<Len, _:Len/binary, _/binary>>, _, 127) ->
     error({too_many_labels, 128});
 from_wire_rest(<<Len, Label:Len/binary, Rest/binary>>, Acc, LabelCount) ->
     %% Add dot separator, then escape label directly into accumulator
-    AccWithDot = <<Acc/binary, $.>>,
-    AccEscaped = escape_label_inline(Label, AccWithDot),
+    AccEscaped = escape_label_chunk(Label, <<Acc/binary, $.>>),
     from_wire_rest(Rest, AccEscaped, LabelCount + 1).
 
-%% Escape label inline, appending directly to accumulator
-%% Optimized to process chunks of safe characters (8, 4, 2 bytes) when possible
-%% VM optimizes binary pattern matching and guards efficiently
-escape_label_inline(<<>>, Acc) ->
-    Acc;
-%% Match 8 bytes at once when all are safe (common case - no escaping needed)
-escape_label_inline(<<A, B, C, D, E, F, G, H, Rest/binary>>, Acc) when
-    A =/= $.,
-    A =/= $\\,
-    B =/= $.,
-    B =/= $\\,
-    C =/= $.,
-    C =/= $\\,
-    D =/= $.,
-    D =/= $\\,
-    E =/= $.,
-    E =/= $\\,
-    F =/= $.,
-    F =/= $\\,
-    G =/= $.,
-    G =/= $\\,
-    H =/= $.,
-    H =/= $\\
-->
-    escape_label_inline(Rest, <<Acc/binary, A, B, C, D, E, F, G, H>>);
-%% Match 4 bytes
-escape_label_inline(<<A, B, C, D, Rest/binary>>, Acc) when
-    A =/= $.,
-    A =/= $\\,
-    B =/= $.,
-    B =/= $\\,
-    C =/= $.,
-    C =/= $\\,
-    D =/= $.,
-    D =/= $\\
-->
-    escape_label_inline(Rest, <<Acc/binary, A, B, C, D>>);
-%% Match 2 bytes
-escape_label_inline(<<A, B, Rest/binary>>, Acc) when
-    A =/= $., A =/= $\\, B =/= $., B =/= $\\
-->
-    escape_label_inline(Rest, <<Acc/binary, A, B>>);
-%% Single byte fallback
-escape_label_inline(<<$., Rest/binary>>, Acc) ->
-    escape_label_inline(Rest, <<Acc/binary, "\\.">>);
-escape_label_inline(<<$\\, Rest/binary>>, Acc) ->
-    escape_label_inline(Rest, <<Acc/binary, "\\\\">>);
-escape_label_inline(<<C, Rest/binary>>, Acc) ->
-    escape_label_inline(Rest, <<Acc/binary, C>>).
+%% Escape a label, appending directly into the accumulator. SWAR optimised.
+escape_label_chunk(<<W:56/unsigned-little, Rest/binary>>, Acc) when ?CLEAN56(W) ->
+    escape_label_chunk(Rest, <<Acc/binary, W:56/unsigned-little>>);
+escape_label_chunk(<<W:32/unsigned-little, Rest/binary>>, Acc) when ?CLEAN32(W) ->
+    escape_label_chunk(Rest, <<Acc/binary, W:32/unsigned-little>>);
+escape_label_chunk(<<$., Rest/binary>>, Acc) ->
+    escape_label_chunk(Rest, <<Acc/binary, "\\.">>);
+escape_label_chunk(<<$\\, Rest/binary>>, Acc) ->
+    escape_label_chunk(Rest, <<Acc/binary, "\\\\">>);
+escape_label_chunk(<<C, Rest/binary>>, Acc) ->
+    escape_label_chunk(Rest, <<Acc/binary, C>>);
+escape_label_chunk(<<>>, Acc) ->
+    Acc.
 
 -doc """
 Convert wire format to domain name with compression support.
@@ -621,17 +608,32 @@ compression pointer is invalid or points outside the message.
 """.
 -spec from_wire(MsgBin :: wire(), DataBin :: wire()) -> {dname(), wire()}.
 from_wire(MsgBin, DataBin) when is_binary(MsgBin), is_binary(DataBin) ->
-    from_wire_first_compressed(MsgBin, DataBin, 0, 0).
+    from_wire_first_compressed(MsgBin, DataBin, <<>>, 0, 0, none).
 
-%% First label - matches structure of from_wire_first
-from_wire_first_compressed(_MsgBin, _Acc, _Count, TotalSize) when 255 < TotalSize ->
+%% Compressed decode threads the accumulator through pointer jumps: a
+%% pointer target's labels are appended straight into the same accumulator
+%% (a rest-position jump appends the '.' separator first) instead of
+%% decoding the target into its own binary and copying that into the
+%% accumulator. "First" position means the next label is appended without a
+%% separator: the start of the name, or right after a followed pointer.
+%% SavedRest is the Rest captured at the first pointer followed — the
+%% remainder from_wire/2 must return. Behavior quirks are preserved
+%% exactly: the label counter restarts on every pointer segment,
+%% decode_loop is checked only for pointers in first position
+%% (pointer-to-pointer chains; any label in between grows TotalSize, which
+%% is bounded), and a pointer to a terminating zero byte yields a
+%% trailing-dot name.
+from_wire_first_compressed(_MsgBin, _DataBin, _Acc, _Count, TotalSize, _SavedRest) when
+    255 < TotalSize
+->
     error({name_too_long, TotalSize});
-from_wire_first_compressed(_MsgBin, <<>>, _Count, _TotalSize) ->
+from_wire_first_compressed(_MsgBin, <<>>, _Acc, _Count, _TotalSize, _SavedRest) ->
     error(truncated);
-from_wire_first_compressed(_MsgBin, <<0, Rest/binary>>, _Count, _TotalSize) ->
-    {<<>>, Rest};
-from_wire_first_compressed(MsgBin, <<3:2, Ptr:14, Rest/binary>>, Count, TotalSize) ->
-    %% Compression pointer as first label
+from_wire_first_compressed(_MsgBin, <<0, Rest/binary>>, Acc, _Count, _TotalSize, SavedRest) ->
+    {Acc, keep_first(SavedRest, Rest)};
+from_wire_first_compressed(
+    MsgBin, <<3:2, Ptr:14, Rest/binary>>, Acc, Count, TotalSize, SavedRest
+) ->
     NewCount = Count + 2,
     case NewCount > byte_size(MsgBin) of
         true ->
@@ -639,65 +641,88 @@ from_wire_first_compressed(MsgBin, <<3:2, Ptr:14, Rest/binary>>, Count, TotalSiz
         false ->
             case MsgBin of
                 <<_:Ptr/binary, PtrDataBin/binary>> ->
-                    {PtrName, _} = from_wire_first_compressed(
-                        MsgBin, PtrDataBin, NewCount, 2 + TotalSize
-                    ),
-                    {PtrName, Rest};
+                    from_wire_first_compressed(
+                        MsgBin,
+                        PtrDataBin,
+                        Acc,
+                        NewCount,
+                        2 + TotalSize,
+                        keep_first(SavedRest, Rest)
+                    );
                 _ ->
                     error({bad_pointer, Ptr})
             end
     end;
-from_wire_first_compressed(_MsgBin, <<Len, _/binary>>, _Count, _TotalSize) when 63 < Len ->
+from_wire_first_compressed(_MsgBin, <<Len, _/binary>>, _Acc, _Count, _TotalSize, _SavedRest) when
+    63 < Len
+->
     error({invalid_label_length, Len});
-from_wire_first_compressed(_MsgBin, <<Len, Rest/binary>>, _Count, _TotalSize) when
+from_wire_first_compressed(_MsgBin, <<Len, Rest/binary>>, _Acc, _Count, _TotalSize, _SavedRest) when
     byte_size(Rest) < Len
 ->
     error(truncated);
-from_wire_first_compressed(MsgBin, <<Len, Label:Len/binary, Rest/binary>>, Count, TotalSize) ->
-    Acc = escape_label_inline(Label, <<>>),
-    from_wire_rest_compressed(MsgBin, Rest, Acc, Count, 1, 1 + Len + TotalSize).
+from_wire_first_compressed(
+    MsgBin, <<Len, Label:Len/binary, Rest/binary>>, Acc, Count, TotalSize, SavedRest
+) ->
+    NewAcc = escape_label_chunk(Label, Acc),
+    from_wire_rest_compressed(MsgBin, Rest, NewAcc, Count, 1, 1 + Len + TotalSize, SavedRest).
 
 %% Rest labels - matches structure of from_wire_rest
-from_wire_rest_compressed(_MsgBin, _, _Acc, _Count, _LabelCount, TotalSize) when 255 < TotalSize ->
+from_wire_rest_compressed(_MsgBin, _, _Acc, _Count, _LabelCount, TotalSize, _SavedRest) when
+    255 < TotalSize
+->
     error({name_too_long, TotalSize});
-from_wire_rest_compressed(_MsgBin, <<>>, _Acc, _Count, _LabelCount, _TotalSize) ->
+from_wire_rest_compressed(_MsgBin, <<>>, _Acc, _Count, _LabelCount, _TotalSize, _SavedRest) ->
     error(truncated);
-from_wire_rest_compressed(_MsgBin, <<0, Rest/binary>>, Acc, _Count, _LabelCount, _TotalSize) ->
-    {Acc, Rest};
 from_wire_rest_compressed(
-    MsgBin, <<3:2, Ptr:14, Rest/binary>>, Acc, Count, _LabelCount, TotalSize
+    _MsgBin, <<0, Rest/binary>>, Acc, _Count, _LabelCount, _TotalSize, SavedRest
+) ->
+    {Acc, keep_first(SavedRest, Rest)};
+from_wire_rest_compressed(
+    MsgBin, <<3:2, Ptr:14, Rest/binary>>, Acc, Count, _LabelCount, TotalSize, SavedRest
 ) ->
     case MsgBin of
         <<_:Ptr/binary, PtrDataBin/binary>> ->
-            {PtrName, _} = from_wire_first_compressed(
-                MsgBin, PtrDataBin, 2 + Count, 2 + TotalSize
-            ),
-            {<<Acc/binary, $., PtrName/binary>>, Rest};
+            from_wire_first_compressed(
+                MsgBin,
+                PtrDataBin,
+                <<Acc/binary, $.>>,
+                2 + Count,
+                2 + TotalSize,
+                keep_first(SavedRest, Rest)
+            );
         _ ->
             error({bad_pointer, Ptr})
     end;
-from_wire_rest_compressed(_MsgBin, <<Len, _/binary>>, _Acc, _Count, _LabelCount, _TotalSize) when
+from_wire_rest_compressed(
+    _MsgBin, <<Len, _/binary>>, _Acc, _Count, _LabelCount, _TotalSize, _SavedRest
+) when
     Len > 63
 ->
     error({invalid_label_length, Len});
-from_wire_rest_compressed(_MsgBin, <<Len, Rest/binary>>, _Acc, _Count, _LabelCount, _TotalSize) when
+from_wire_rest_compressed(
+    _MsgBin, <<Len, Rest/binary>>, _Acc, _Count, _LabelCount, _TotalSize, _SavedRest
+) when
     byte_size(Rest) < Len
 ->
     error(truncated);
-from_wire_rest_compressed(_MsgBin, <<Len, _:Len/binary, _/binary>>, _Acc, _Count, 127, _) ->
+from_wire_rest_compressed(
+    _MsgBin, <<Len, _:Len/binary, _/binary>>, _Acc, _Count, 127, _, _SavedRest
+) ->
     error({too_many_labels, 128});
 from_wire_rest_compressed(
-    MsgBin,
-    <<Len, Label:Len/binary, Rest/binary>>,
-    Acc,
-    Count,
-    LabelCount,
-    TotalSize
+    MsgBin, <<Len, Label:Len/binary, Rest/binary>>, Acc, Count, LabelCount, TotalSize, SavedRest
 ) ->
     %% Add dot separator, then escape label directly into accumulator
-    AccWithDot = <<Acc/binary, $.>>,
-    AccEscaped = escape_label_inline(Label, AccWithDot),
-    from_wire_rest_compressed(MsgBin, Rest, AccEscaped, Count, 1 + LabelCount, 1 + Len + TotalSize).
+    AccEscaped = escape_label_chunk(Label, <<Acc/binary, $.>>),
+    from_wire_rest_compressed(
+        MsgBin, Rest, AccEscaped, Count, 1 + LabelCount, 1 + Len + TotalSize, SavedRest
+    ).
+
+%% The remainder returned by from_wire/2 is the Rest at the first pointer
+%% followed; later pointer sites don't change it.
+keep_first(none, Rest) -> Rest;
+keep_first(Saved, _Rest) -> Saved.
 
 -doc """
 Returns provided name with case-insensitive characters in uppercase.
@@ -708,14 +733,15 @@ to_upper(Data) when is_binary(Data) ->
 
 -compile(
     {inline, [
-        lower_word56/1, upper_word56/1, lower_byte/1, upper_byte/1, are_equal_ci/2, has_upper_word/1
+        lower_word56/1,
+        upper_word56/1,
+        lower_byte/1,
+        upper_byte/1,
+        are_equal_ci/2,
+        has_upper_word/1,
+        keep_first/2
     ]}
 ).
-
-%% 56-bit (7-byte) SWAR constants — stays within BEAM small integer range
-%% (60-bit on 64-bit systems), avoiding bignum allocation.
--define(ONES56, 16#01010101010101).
--define(HIGHS56, 16#80808080808080).
 
 %% Bitwise SWAR case conversion for 7 packed bytes.
 %% Carry-safe: even for bytes >= 128, (0x80 | b) - 91 >= 37, so no borrow


### PR DESCRIPTION
Two changes to the wire-to-text name decoder, prototyped as separate axes and benchmarked factorially on both machines below:

- The per-label escape walker (previously escape_label_inline/2, now escape_label_chunk/2) matched 8 individual bytes per chunk and ran 16 guard comparisons on them. It now extracts a 56-bit word (then a 32-bit word for the tail) and proves it free of '.' and '\' with an exact SWAR zero-byte test in a guard: one wide load, a dozen integer ops and one wide append per 7 bytes, instead of 8 loads, 16 compares and 8 byte writes. A dirty byte falls through to the escaping byte clauses and the walker re-enters the word clauses right after it. The label is still only ever matched, never appended as a term, so it stays a match context and the allocation profile is unchanged.

- The compressed decoder (from_wire/2) previously materialized every rest-position pointer target as its own PtrName binary and then copied it again via <<Acc/binary, $., PtrName/binary>>, so suffix bytes were written once per pointer-nesting level. The accumulator is now threaded through pointer jumps: a jump appends the '.' separator and keeps decoding the target's labels into the same accumulator, and the Rest captured at the first pointer followed is carried along (keep_first/2) and returned at the terminal zero. Every byte of the name is written exactly once regardless of pointer depth.

Behavior quirks are preserved exactly: the 127-label counter restarts on every pointer segment, decode_loop is checked only for pointers in first position (pointer-to-pointer chains), a pointer to a terminating zero still yields a trailing-dot name, and the Count/TotalSize arithmetic is identical so a raised {name_too_long, N} carries the same N. This was verified by a parity harness comparing old and new implementations across 26,434 cases: valid and malformed wires, escaped labels, 255-byte boundary names, pure/suffix/chained/forward pointers, pointer loops in both the decode_loop and name_too_long flavors, every byte-prefix of every wire and message (truncating MsgBin and DataBin independently), and single-byte corruption sweeps, matching both return values and raised error class/reason, run on both machines below. make test (lint, xref, dialyzer, ct, cover) passes.

Rejected alternatives, measured: scanning a label and then appending it wholesale materializes a ~40 B sub-binary per label (+15-20% allocation, which erased the win); a multi-pattern binary:match clean check loses to inline scans on short labels (1.4-2.4x slower); and threading the pointer accumulator while keeping the byte-guard walker measured slower than both the old code and the shipped combination.

Benchmarks (Benchee, Erlang/OTP 29.0.3, JIT enabled, average time before -> after; sub-200 ns M4 rows are quantized by its 41.7 ns timer tick, so the Ryzen column is the sharper signal there):

from_wire/1:

```
  input                    Apple M4 Pro (macOS)    AMD Ryzen 9 9950X3D
  1-label                  86 -> 88 ns    0.97x    97 -> 86 ns    1.13x
  2-label                  128 -> 115 ns  1.11x    139 -> 114 ns  1.22x
  3-label                  175 -> 167 ns  1.05x    186 -> 180 ns  1.03x
  8-label                  325 -> 313 ns  1.04x    360 -> 331 ns  1.09x
  63B label                192 -> 157 ns  1.22x    193 -> 164 ns  1.18x
  v4 reverse PTR           250 -> 239 ns  1.05x    272 -> 252 ns  1.08x
  v6 reverse PTR (34 lbl)  1.03 -> 1.05 us 0.98x   1.07 -> 1.09 us 0.98x
  50x 1-char labels        1.40 -> 1.40 us 1.00x   1.48 -> 1.52 us 0.97x
  escaped label            185 -> 162 ns  1.14x    196 -> 167 ns  1.17x
```

from_wire/2:

```
  input                    Apple M4 Pro (macOS)    AMD Ryzen 9 9950X3D
  plain 2-label            139 -> 133 ns  1.04x    140 -> 121 ns  1.16x
  plain 3-label            181 -> 189 ns  0.96x    208 -> 190 ns  1.10x
  plain 8-label            343 -> 342 ns  1.00x    390 -> 359 ns  1.09x
  pure pointer             201 -> 215 ns  0.94x    224 -> 203 ns  1.10x
  suffix pointer           227 -> 204 ns  1.11x    220 -> 205 ns  1.07x
  two-hop chain            320 -> 272 ns  1.18x    297 -> 253 ns  1.18x
  10-hop chain             1.13 -> 0.76 us 1.48x   0.95 -> 0.68 us 1.39x
  v6 PTR plain             1.15 -> 1.18 us 0.97x   1.19 -> 1.17 us 1.02x
  escaped label            187 -> 188 ns  0.99x    211 -> 190 ns  1.11x
```

Memory usage and reduction counts were identical on both machines (from_wire/2, before -> after):

```
  input                    memory               reductions
  plain 2-label            456 B (equal)        14 -> 13
  plain 3-label            640 B (equal)        19 (equal)
  plain 8-label            1.61 KB (equal)      42 -> 43
  pure pointer             808 -> 784 B         21 -> 20
  suffix pointer           832 -> 744 B         21 -> 20
  two-hop chain            1.21 -> 1.04 KB      27 -> 25
  10-hop chain             4.70 -> 3.84 KB      99 -> 80
  v6 PTR plain             6.65 KB (equal)      148 -> 149
  escaped label            640 B (equal)        20 -> 19
```

from_wire/1 memory is byte-identical on every input; reduction counts differ by at most 1.

The known soft spot is names made of 1-2 byte labels (v6 reverse PTRs, the 50x 1-char stress input): such labels never reach the word clauses and pay two failed clause dispatches each, for a consistent 2-3% slowdown on those shapes. Everything else is equal or faster on both machines.