### PR TITLE
Optimize dns_decode: fewer allocations and dispatches on the decode path

### DIFF
--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -213,58 +213,71 @@ create_message_from_header(Id, QR, OC, AA, TC, RD, RA, AD, CD, RC, QC, ANC, AUC,
         adc = ADC
     }.
 
+%% The #dns_message{} record is updated exactly once, on completion — updating it
+%% per section would copy the full 19-word record four times per message.
 -spec decode_body(dns:message_bin(), binary(), dns:message()) ->
     dns:message() | {dns:decode_error(), dns:message() | undefined, binary()}.
-decode_body(MsgBin, Rest0, #dns_message{} = Msg0) ->
-    maybe
-        {Msg1, Rest1} ?= decode_questions(MsgBin, Rest0, Msg0),
-        {Msg2, Rest2} ?= decode_answers(MsgBin, Rest1, Msg1),
-        {Msg3, Rest3} ?= decode_authority(MsgBin, Rest2, Msg2),
-        {Msg4, Rest4} ?= decode_additional(MsgBin, Rest3, Msg3),
-        decode_finished(MsgBin, Rest4, Msg4)
-    else
-        Other ->
-            Other
-    end.
-
--spec decode_questions(dns:message_bin(), binary(), dns:message()) ->
-    {dns:message(), binary()} | {dns:decode_error(), dns:message(), binary()}.
-decode_questions(MsgBin, Body, #dns_message{qc = QC} = Msg) ->
-    case decode_message_questions(MsgBin, Body, QC, []) of
-        {Questions, Rest} ->
-            {Msg#dns_message{questions = Questions}, Rest};
+decode_body(MsgBin, Rest0, #dns_message{qc = QC} = Msg0) ->
+    case decode_message_questions(MsgBin, Rest0, QC, []) of
+        {Questions, Rest1} ->
+            decode_body_answers(MsgBin, Rest1, Msg0, Questions);
         {Error, Questions, Rest} ->
-            {Error, Msg#dns_message{questions = Questions}, Rest}
+            {Error, Msg0#dns_message{questions = Questions}, Rest}
     end.
 
--spec decode_answers(dns:message_bin(), binary(), dns:message()) ->
-    {dns:message(), binary()} | {dns:decode_error(), dns:message(), binary()}.
-decode_answers(MsgBin, Body, #dns_message{anc = ANC} = Msg) ->
+-spec decode_body_answers(dns:message_bin(), binary(), dns:message(), dns:questions()) ->
+    dns:message() | {dns:decode_error(), dns:message(), binary()}.
+decode_body_answers(MsgBin, Body, #dns_message{anc = ANC} = Msg0, Questions) ->
     case decode_message_body(MsgBin, Body, ANC) of
-        {RR, Rest} ->
-            {Msg#dns_message{answers = RR}, Rest};
-        {Error, RR, Rest} ->
-            {Error, Msg#dns_message{answers = RR}, Rest}
+        {Answers, Rest} ->
+            decode_body_authority(MsgBin, Rest, Msg0, Questions, Answers);
+        {Error, Answers, Rest} ->
+            {Error, Msg0#dns_message{questions = Questions, answers = Answers}, Rest}
     end.
 
--spec decode_authority(dns:message_bin(), binary(), dns:message()) ->
-    {dns:message(), binary()} | {dns:decode_error(), dns:message(), binary()}.
-decode_authority(MsgBin, Body, #dns_message{auc = AUC} = Msg) ->
+-spec decode_body_authority(
+    dns:message_bin(), binary(), dns:message(), dns:questions(), dns:answers()
+) ->
+    dns:message() | {dns:decode_error(), dns:message(), binary()}.
+decode_body_authority(MsgBin, Body, #dns_message{auc = AUC} = Msg0, Questions, Answers) ->
     case decode_message_body(MsgBin, Body, AUC) of
-        {RR, Rest} ->
-            {Msg#dns_message{authority = RR}, Rest};
-        {Error, RR, Rest} ->
-            {Error, Msg#dns_message{authority = RR}, Rest}
+        {Authority, Rest} ->
+            decode_body_additional(MsgBin, Rest, Msg0, Questions, Answers, Authority);
+        {Error, Authority, Rest} ->
+            {Error,
+                Msg0#dns_message{
+                    questions = Questions,
+                    answers = Answers,
+                    authority = Authority
+                },
+                Rest}
     end.
 
--spec decode_additional(dns:message_bin(), binary(), dns:message()) ->
-    {dns:message(), binary()} | {dns:decode_error(), dns:message(), binary()}.
-decode_additional(MsgBin, Body, #dns_message{adc = ADC} = Msg) ->
+-spec decode_body_additional(
+    dns:message_bin(), binary(), dns:message(), dns:questions(), dns:answers(), dns:authority()
+) ->
+    dns:message() | {dns:decode_error(), dns:message(), binary()}.
+decode_body_additional(
+    MsgBin, Body, #dns_message{adc = ADC} = Msg0, Questions, Answers, Authority
+) ->
     case decode_message_additional(MsgBin, Body, ADC) of
-        {RR, Rest} ->
-            {Msg#dns_message{additional = RR}, Rest};
-        {Error, RR, Rest} ->
-            {Error, Msg#dns_message{additional = RR}, Rest}
+        {Additional, Rest} ->
+            Msg = Msg0#dns_message{
+                questions = Questions,
+                answers = Answers,
+                authority = Authority,
+                additional = Additional
+            },
+            decode_finished(MsgBin, Rest, Msg);
+        {Error, Additional, Rest} ->
+            {Error,
+                Msg0#dns_message{
+                    questions = Questions,
+                    answers = Answers,
+                    authority = Authority,
+                    additional = Additional
+                },
+                Rest}
     end.
 
 -spec decode_finished(dns:message_bin(), binary(), dns:message()) ->

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -992,6 +992,8 @@ bin_to_key_tag(Binary) when is_binary(Binary) ->
 -spec do_bin_to_key_tag(binary(), non_neg_integer()) -> dns:uint16().
 do_bin_to_key_tag(<<>>, AC) ->
     (AC + ((AC bsr 16) band 16#FFFF)) band 16#FFFF;
+do_bin_to_key_tag(<<A:16, B:16, C:16, D:16, Rest/binary>>, AC) ->
+    do_bin_to_key_tag(Rest, AC + A + B + C + D);
 do_bin_to_key_tag(<<X:16, Rest/binary>>, AC) ->
     do_bin_to_key_tag(Rest, AC + X);
 do_bin_to_key_tag(<<X:8>>, AC) ->

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -25,7 +25,15 @@
 -elvis([
     {elvis_style, max_function_arity, #{ignore => [{dns_decode, create_message_from_header, 14}]}}
 ]).
--compile({inline, [decode_bool/1, round_pow/1, create_message_from_header/14]}).
+-compile(
+    {inline, [
+        decode_bool/1,
+        round_pow/1,
+        create_message_from_header/14,
+        decode_bmp_byte/3,
+        bmp_bit/3
+    ]}
+).
 
 -spec decode(dns:message_bin()) ->
     dns:message() | {dns:decode_error(), dns:message() | undefined, binary()}.
@@ -1014,29 +1022,38 @@ do_decode_nsec_types(<<>>, Types) ->
     lists:reverse(Types);
 do_decode_nsec_types(<<WindowNum:8, BMPLength:8, BMP:BMPLength/binary, Rest/binary>>, Types) ->
     BaseNo = WindowNum * 256,
-    NewTypes = do_decode_nsec_types(BMP, BaseNo, Types),
+    NewTypes = decode_bmp_bytes(BMP, BaseNo, Types),
     do_decode_nsec_types(Rest, NewTypes).
 
--spec do_decode_nsec_types(bitstring(), non_neg_integer(), [non_neg_integer()]) ->
+-spec decode_bmp_bytes(binary(), non_neg_integer(), [non_neg_integer()]) ->
     [non_neg_integer()].
-do_decode_nsec_types(<<>>, _Num, Types) ->
+decode_bmp_bytes(<<>>, _Num, Types) ->
     Types;
-do_decode_nsec_types(<<0:1, Rest/bitstring>>, Num, Types) ->
-    do_decode_nsec_types(Rest, Num + 1, Types);
-do_decode_nsec_types(<<1:1, Rest/bitstring>>, Num, Types) ->
-    do_decode_nsec_types(Rest, Num + 1, [Num | Types]).
+decode_bmp_bytes(<<0, Rest/binary>>, Num, Types) ->
+    decode_bmp_bytes(Rest, Num + 8, Types);
+decode_bmp_bytes(<<B, Rest/binary>>, Num, Types) ->
+    decode_bmp_bytes(Rest, Num + 8, decode_bmp_byte(B, Num, Types)).
 
--spec decode_nxt_bmp(bitstring()) -> [non_neg_integer()].
+%% Bits are MSB-first: bit 7 of B is type Num, bit 0 is type Num + 7.
+%% Set types are prepended in ascending order; callers reverse once at the end.
+-spec decode_bmp_byte(byte(), non_neg_integer(), [non_neg_integer()]) -> [non_neg_integer()].
+decode_bmp_byte(B, Num, Acc0) ->
+    Acc1 = bmp_bit(B band 2#10000000, Num, Acc0),
+    Acc2 = bmp_bit(B band 2#01000000, Num + 1, Acc1),
+    Acc3 = bmp_bit(B band 2#00100000, Num + 2, Acc2),
+    Acc4 = bmp_bit(B band 2#00010000, Num + 3, Acc3),
+    Acc5 = bmp_bit(B band 2#00001000, Num + 4, Acc4),
+    Acc6 = bmp_bit(B band 2#00000100, Num + 5, Acc5),
+    Acc7 = bmp_bit(B band 2#00000010, Num + 6, Acc6),
+    bmp_bit(B band 2#00000001, Num + 7, Acc7).
+
+-spec bmp_bit(non_neg_integer(), non_neg_integer(), [non_neg_integer()]) -> [non_neg_integer()].
+bmp_bit(0, _Num, Acc) -> Acc;
+bmp_bit(_, Num, Acc) -> [Num | Acc].
+
+-spec decode_nxt_bmp(binary()) -> [non_neg_integer()].
 decode_nxt_bmp(BMP) ->
-    do_decode_nxt_bmp(BMP, 0, []).
-
--spec do_decode_nxt_bmp(bitstring(), non_neg_integer(), [non_neg_integer()]) -> [non_neg_integer()].
-do_decode_nxt_bmp(<<>>, _Offset, Types) ->
-    lists:reverse(Types);
-do_decode_nxt_bmp(<<1:1, Rest/bitstring>>, Offset, Types) ->
-    do_decode_nxt_bmp(Rest, Offset + 1, [Offset | Types]);
-do_decode_nxt_bmp(<<0:1, Rest/bitstring>>, Offset, Types) ->
-    do_decode_nxt_bmp(Rest, Offset + 1, Types).
+    lists:reverse(decode_bmp_bytes(BMP, 0, [])).
 
 -spec decode_svcb_svc_params(binary()) -> dns:svcb_svc_params().
 decode_svcb_svc_params(Bin) ->

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -978,9 +978,8 @@ decode_dsa_key(T, Q, KeyBin, Bin) ->
 -spec decode_text(binary()) -> [binary()].
 decode_text(<<>>) ->
     [];
-decode_text(Bin) when is_binary(Bin) ->
-    {RB, String} = decode_string(Bin),
-    [String | decode_text(RB)].
+decode_text(<<Len, String:Len/binary, Rest/binary>>) ->
+    [String | decode_text(Rest)].
 
 -spec decode_string(nonempty_binary()) -> {binary(), binary()}.
 decode_string(<<Len, Bin:Len/binary, Rest/binary>>) ->


### PR DESCRIPTION
Four independent optimizations to `dns_decode`, one commit each. Wire-format behavior is unchanged — return values *and* raised errors are identical, verified by an equivalence harness (details below).

### Changes

1. **`decode_text/1` matches character-strings inline** — drops one `{Rest, Str}` tuple allocation and one call per string (TXT/SPF/HINFO/RESINFO/WALLET) and lets the compiler delay sub-binary creation. `decode_string/1` remains for NAPTR.
2. **DNSKEY key-tag fold unrolled 4×** — `do_bin_to_key_tag/2` folds four 16-bit words per iteration instead of one.
3. **NSEC/NSEC3/CSYNC/NXT type bitmaps decoded byte-wise** — bitmaps were walked one *bit* (one match-context iteration) at a time. They always arrive as whole-byte sub-binaries, so a zero byte is now skipped in a single dispatch and a non-zero byte expands through eight inlined integer `band` tests. NSEC and NXT share one helper; specs tighten `bitstring()` → `binary()`.
4. **`#dns_message{}` assembled once** — `decode_body` updated the 19-word message record once per section, i.e. four full record copies per message. Section lists now travel through function arguments and the record is updated exactly once; error paths build the partial record at the error site, preserving the exact partial-message error tuples.

### Correctness

`bench/decode_bench.exs` proves result equivalence between old and new implementations across **21,505 cases** before benchmarking: realistic messages (compression, DNSSEC, DNSKEY, EDNS, cookie/NOTIFY/UPDATE), all 64 opcode×QR×TC header combinations, handcrafted malformed messages (bad pointer, pointer loop, bad cookie, bad TXT length, …), every byte-prefix of every corpus message, and single-byte corruption sweeps — comparing values and raised errors for both `decode/1` and `decode_query/1`. `make test` passes (684 tests, lint/xref/dialyzer/cover).

### Benchmarks

**`decode_query/1` (inbound query hot path):**

  | Input | Throughput | Reductions | Memory |
  |---|---|---|---|
  | plain A query | **+9%** | −11% | −9% |
  | EDNS(DO) query | **+7%** | −10% | −5% |
  | cookie-only query (RFC 7873) | **+7%** | −10% | **−21%** |
  | NOTIFY | **+13%** | −11% | −9% |

  **`decode/1` (full message decode):**

  | Input | Throughput | Reductions | Memory |
  |---|---|---|---|
  | 01 simple_query (29B) | +7% | −11% | −9% |
  | 02 simple_response (45B) | +4% | −7% | −4% |
  | 03 medium_response, 10 RRs | +2% | −2% | −1% |
  | 04 large_response, 50 RRs | −7% | +0.6% | −0.2% |
  | 05 compressed_names, 20 RRs | +1% | −1% | −0.3% |
  | 06 mixed_record_types | +1% | −6% | −3% |
  | 07 dnssec_response | −1% | −4% | −2% |
  | 08 dnskey_response | +5% | **−24%** | −2% |
  | 09 all_record_types (2.3KB) | ±0% | −2% | −1% |
  | 10 txt_heavy (8 TXT × 4 strings) | **+8%** | −11% | **−17%** |
  | 11 nsec_heavy (12 NSEC/NSEC3) | +5% | **−51%** | −0.3% |
  | 12 edns_query | **+8%** | −10% | −5% |
  | 13–15 cookie/notify/update | ±0% to +11% | −10% | −9 to −21% |

The one negative throughput number (04, −7% average) sits on essentially flat reductions (+0.6%) and lower memory; that input is dominated by `dns_domain:from_wire/2` name decoding and its distribution is heavily outlier-skewed (±86% deviation) — a macOS run of the same suite showed it at −2% average with a *better* median. Everything the changed code actually touches moves in the right direction on both boxes.