### PR TITLE
Fix NSEC-family bitmap encoding and MINFO decoding wire-format bugs\

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - NSEC/NSEC3/CSYNC type bitmap encoding shifted every type after the first by one bit position in any window whose first present type is a multiple of 256 (e.g. `[URI (256), CAA (257)]` encoded as the bitmap for `{URI, AVC (258)}`). NXT bitmaps had the same off-by-one after type 0.
+- MINFO records failed to decode inside full messages (`formerr`) due to swapped `dns_domain:from_wire/2` arguments in the MINFO rdata decoder.
 
 ## v5.0.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+### Fixed
+
+- NSEC/NSEC3/CSYNC type bitmap encoding shifted every type after the first by one bit position in any window whose first present type is a multiple of 256 (e.g. `[URI (256), CAA (257)]` encoded as the bitmap for `{URI, AVC (258)}`). NXT bitmaps had the same off-by-one after type 0.
+
 ## v5.0.14
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
-### Fixed
-
-- NSEC/NSEC3/CSYNC type bitmap encoding shifted every type after the first by one bit position in any window whose first present type is a multiple of 256 (e.g. `[URI (256), CAA (257)]` encoded as the bitmap for `{URI, AVC (258)}`). NXT bitmaps had the same off-by-one after type 0.
-- MINFO records failed to decode inside full messages (`formerr`) due to swapped `dns_domain:from_wire/2` arguments in the MINFO rdata decoder.
-
 ## v5.0.14
 
 ### Updated
@@ -22,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Correct name compression in the additional section of `encode_message/2` for non-EDNS responses
+- NSEC/NSEC3/CSYNC/NXT type bitmap encoding shifted every type after the first by one bit position in any window whose first present type is a multiple of 256
+- MINFO records failed to decode inside full messages (`formerr`) due to swapped `dns_domain:from_wire/2` arguments in the MINFO rdata decoder
 
 ## v5.0.13
 

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -776,7 +776,7 @@ decode_rrdata(MsgBin, _Class, ?DNS_TYPE_MB, Bin) ->
 decode_rrdata(MsgBin, _Class, ?DNS_TYPE_MG, Bin) ->
     #dns_rrdata_mg{madname = decode_dnameonly(MsgBin, Bin)};
 decode_rrdata(MsgBin, _Class, ?DNS_TYPE_MINFO, Bin) when is_binary(Bin) ->
-    {RMB, EMB} = dns_domain:from_wire(Bin, MsgBin),
+    {RMB, EMB} = dns_domain:from_wire(MsgBin, Bin),
     #dns_rrdata_minfo{rmailbx = RMB, emailbx = decode_dnameonly(MsgBin, EMB)};
 decode_rrdata(MsgBin, _Class, ?DNS_TYPE_MR, Bin) ->
     #dns_rrdata_mr{newname = decode_dnameonly(MsgBin, Bin)};

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -1184,49 +1184,40 @@ encode_nsec_types([]) ->
 encode_nsec_types([_ | _] = UnsortedTypes) ->
     [FirstType | _] = Types = lists:usort(UnsortedTypes),
     FirstWindowNum = FirstType div 256,
-    FirstLastType = FirstWindowNum * 256,
-    do_encode_nsec_types(<<>>, <<>>, FirstWindowNum, FirstLastType, Types).
+    do_encode_nsec_types(<<>>, <<>>, FirstWindowNum, Types).
 
--spec do_encode_nsec_types(binary(), bitstring(), integer(), number(), [integer()]) ->
+-spec do_encode_nsec_types(binary(), bitstring(), integer(), [integer()]) ->
     <<_:16, _:_*8>>.
-do_encode_nsec_types(Bin, BMP0, WindowNum, _LastType, []) ->
+do_encode_nsec_types(Bin, BMP0, WindowNum, []) ->
     BMP = pad_bmp(BMP0),
     BMPSize = byte_size(BMP),
     <<Bin/binary, WindowNum:8, BMPSize:8, BMP:BMPSize/binary>>;
-do_encode_nsec_types(Bin, BMP0, OldWindowNum, _LastType, [Type | _] = Types) when
+do_encode_nsec_types(Bin, BMP0, OldWindowNum, [Type | _] = Types) when
     Type div 256 =/= OldWindowNum
 ->
     BMP = pad_bmp(BMP0),
     BMPSize = byte_size(BMP),
     NewBin = <<Bin/binary, OldWindowNum:8, BMPSize:8, BMP:BMPSize/binary>>,
-    NewBMP = <<>>,
     NewWindowNum = Type div 256,
-    NewLastType = NewWindowNum * 256,
-    do_encode_nsec_types(NewBin, NewBMP, NewWindowNum, NewLastType, Types);
-do_encode_nsec_types(Bin, BMP, WindowNum, LastType, [Type | Types]) ->
-    PadBy =
-        case LastType rem 256 of
-            0 -> Type rem 256;
-            _ -> Type - LastType - 1
-        end,
+    do_encode_nsec_types(NewBin, <<>>, NewWindowNum, Types);
+do_encode_nsec_types(Bin, BMP, WindowNum, [Type | Types]) ->
+    PadBy = Type rem 256 - bit_size(BMP),
     NewBMP = <<BMP/bitstring, 0:PadBy/unit:1, 1:1>>,
-    do_encode_nsec_types(Bin, NewBMP, WindowNum, Type, Types).
+    do_encode_nsec_types(Bin, NewBMP, WindowNum, Types).
 
 -spec encode_nxt_bmp([non_neg_integer()]) -> bitstring().
 encode_nxt_bmp(UnsortedTypes) when is_list(UnsortedTypes) ->
     Types = lists:usort(UnsortedTypes),
-    encode_nxt_bmp(Types, 0, <<>>).
+    encode_nxt_bmp(Types, <<>>).
 
--spec encode_nxt_bmp([non_neg_integer()], non_neg_integer(), bitstring()) -> bitstring().
-encode_nxt_bmp([], _LastType, BMP) ->
+-spec encode_nxt_bmp([non_neg_integer()], bitstring()) -> bitstring().
+encode_nxt_bmp([], BMP) ->
     pad_bmp(BMP);
-encode_nxt_bmp([Type | Types], 0, BMP) ->
-    NewBMP = <<BMP/bitstring, 0:Type/unit:1, 1:1>>,
-    encode_nxt_bmp(Types, Type, NewBMP);
-encode_nxt_bmp([Type | Types], LastType, BMP) ->
-    PadBy = Type - LastType - 1,
+encode_nxt_bmp([Type | Types], BMP) ->
+    %% The bit for Type sits at absolute position Type in the (windowless) bitmap.
+    PadBy = Type - bit_size(BMP),
     NewBMP = <<BMP/bitstring, 0:PadBy/unit:1, 1:1>>,
-    encode_nxt_bmp(Types, Type, NewBMP).
+    encode_nxt_bmp(Types, NewBMP).
 
 -spec pad_bmp(bitstring()) -> bitstring().
 pad_bmp(BMP) when is_binary(BMP) -> BMP;

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -62,7 +62,8 @@ groups() ->
         {rrdata, [parallel], [
             decode_encode_rrdata_wire_samples,
             decode_encode_rrdata,
-            encode_nsec_type_bitmaps
+            encode_nsec_type_bitmaps,
+            decode_minfo_in_message
         ]},
         {svcb, [parallel], [
             decode_encode_svcb_params,
@@ -916,6 +917,36 @@ encode_nsec_type_bitmaps(_) ->
         ?DNS_CLASS_IN, #dns_rrdata_nxt{dname = <<"a">>, types = [0, 5]}
     ),
     ?assertEqual(<<2#10000100>>, NxtBMP).
+
+%% MINFO rdata names must decode inside a full message, where the rdata is a
+%% sub-binary of the message and its names compress against earlier names.
+%% Regression for swapped from_wire/2 arguments, which the rdata-level
+%% round-trip cannot catch (there MsgBin and Bin are the same binary).
+decode_minfo_in_message(_) ->
+    Rdata = #dns_rrdata_minfo{
+        rmailbx = <<"rmail.example.com">>,
+        emailbx = <<"email.example.com">>
+    },
+    Msg = #dns_message{
+        id = 1234,
+        qr = true,
+        qc = 1,
+        anc = 1,
+        questions = [
+            #dns_query{name = <<"example.com">>, type = ?DNS_TYPE_MINFO, class = ?DNS_CLASS_IN}
+        ],
+        answers = [
+            #dns_rr{
+                name = <<"example.com">>,
+                type = ?DNS_TYPE_MINFO,
+                class = ?DNS_CLASS_IN,
+                ttl = 3600,
+                data = Rdata
+            }
+        ]
+    },
+    Decoded = dns:decode_message(dns:encode_message(Msg)),
+    ?assertMatch(#dns_message{answers = [#dns_rr{data = Rdata}]}, Decoded).
 
 uri_decode_normalization(_) ->
     %% Test that URI targets are normalized during decoding

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -61,7 +61,8 @@ groups() ->
         ]},
         {rrdata, [parallel], [
             decode_encode_rrdata_wire_samples,
-            decode_encode_rrdata
+            decode_encode_rrdata,
+            encode_nsec_type_bitmaps
         ]},
         {svcb, [parallel], [
             decode_encode_svcb_params,
@@ -839,6 +840,32 @@ decode_encode_rrdata(_) ->
         }},
         {?DNS_TYPE_EUI64, #dns_rrdata_eui64{
             address = <<16#00, 16#1A, 16#2B, 16#3C, 16#4D, 16#5E, 16#6F, 16#70>>
+        }},
+        %% Bitmap windows whose first present type is a multiple of 256
+        %% (URI = 256, CAA = 257; TA = 32768, DLV = 32769): regression for the
+        %% off-by-one that encoded [256, 257] as the bitmap for {256, 258}
+        {?DNS_TYPE_NSEC, #dns_rrdata_nsec{
+            next_dname = <<"next.example.com">>,
+            types = [?DNS_TYPE_URI, ?DNS_TYPE_CAA]
+        }},
+        {?DNS_TYPE_NSEC, #dns_rrdata_nsec{
+            next_dname = <<"next.example.com">>,
+            types = [
+                ?DNS_TYPE_A, ?DNS_TYPE_RRSIG, ?DNS_TYPE_URI, ?DNS_TYPE_CAA, 32768, ?DNS_TYPE_DLV
+            ]
+        }},
+        {?DNS_TYPE_NSEC3, #dns_rrdata_nsec3{
+            hash_alg = 1,
+            opt_out = true,
+            iterations = 5,
+            salt = <<16#AB, 16#CD>>,
+            hash = <<"12345678901234567890">>,
+            types = [?DNS_TYPE_URI, ?DNS_TYPE_CAA]
+        }},
+        {?DNS_TYPE_CSYNC, #dns_rrdata_csync{
+            soa_serial = 2025072400,
+            flags = 1,
+            types = [?DNS_TYPE_URI, ?DNS_TYPE_CAA]
         }}
     ],
     [
@@ -854,6 +881,41 @@ decode_encode_rrdata(_) ->
         end
      || {Type, Data} <- Cases
     ].
+
+%% Exact wire assertions for NSEC/CSYNC type bitmaps (RFC 4034 §4.1.2): the bit
+%% for type T must land at position T rem 256 of its window, including when the
+%% window's first present type is a multiple of 256.
+encode_nsec_type_bitmaps(_) ->
+    Cases = [
+        {[?DNS_TYPE_A], <<0, 1, 2#01000000>>},
+        {[?DNS_TYPE_A, ?DNS_TYPE_NS], <<0, 1, 2#01100000>>},
+        {
+            [?DNS_TYPE_RRSIG, ?DNS_TYPE_NSEC, ?DNS_TYPE_DNSKEY],
+            <<0, 7, 0, 0, 0, 0, 0, 2#00000011, 2#10000000>>
+        },
+        {[?DNS_TYPE_URI], <<1, 1, 2#10000000>>},
+        {[?DNS_TYPE_CAA], <<1, 1, 2#01000000>>},
+        {[?DNS_TYPE_URI, ?DNS_TYPE_CAA], <<1, 1, 2#11000000>>},
+        {[32768, ?DNS_TYPE_DLV], <<128, 1, 2#11000000>>},
+        {[?DNS_TYPE_A, ?DNS_TYPE_URI, ?DNS_TYPE_CAA], <<0, 1, 2#01000000, 1, 1, 2#11000000>>},
+        %% type 0 (reserved) occupies bit 0 of window 0
+        {[0, ?DNS_TYPE_A], <<0, 1, 2#11000000>>}
+    ],
+    [
+        begin
+            <<_SOASerial:32, _Flags:16, BitmapWire/binary>> = dns_encode:encode_rrdata(
+                ?DNS_CLASS_IN, #dns_rrdata_csync{soa_serial = 0, flags = 0, types = Types}
+            ),
+            ?assertEqual(Expected, BitmapWire, Types)
+        end
+     || {Types, Expected} <- Cases
+    ],
+    %% NXT (RFC 2535 §5.2) uses a windowless bitmap; type 0 followed by another
+    %% type exercised the same off-by-one
+    <<1, $a, 0, NxtBMP/binary>> = dns_encode:encode_rrdata(
+        ?DNS_CLASS_IN, #dns_rrdata_nxt{dname = <<"a">>, types = [0, 5]}
+    ),
+    ?assertEqual(<<2#10000100>>, NxtBMP).
 
 uri_decode_normalization(_) ->
     %% Test that URI targets are normalized during decoding


### PR DESCRIPTION
Two independent, long-standing wire-format bugs. The first was found by review of the bitmap encoder while scoping the dns_encode optimization work; the second was caught by the smoke check of the new encode benchmark harness.