### PR TITLE
Fix premature OPT RR and additional-section dropping near max_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct name compression in the additional section of `encode_message/2` for non-EDNS responses
 - NSEC/NSEC3/CSYNC/NXT type bitmap encoding shifted every type after the first by one bit position in any window whose first present type is a multiple of 256
 - MINFO records failed to decode inside full messages (`formerr`) due to swapped `dns_domain:from_wire/2` arguments in the MINFO rdata decoder
+- `encode_message/2` subtracted the question section twice when sizing the OPT RR and additional records, wrongly dropping them (including the EDNS OPT RR, contra RFC 6891) from responses within question-size bytes of `max_size`
 
 ## v5.0.13
 

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -169,12 +169,14 @@ encode_message_default(
                     <<Head/binary, Acc1/binary, OptRRBinMin/binary>>
             end;
         {Body, CompMap2} ->
+            %% Body includes the question section, so subtract it from SpaceLeft0:
+            %% SpaceLeft1 would subtract the question bytes a second time
             BodySize = byte_size(Body),
             {OptRRBin, Ad0} = encode_message_pop_optrr(Additional),
             OptRRBinSize = byte_size(OptRRBin),
             Pos2 = ?HEADER_SIZE + BodySize,
             #dns_message{anc = ANC, auc = AUC} = Msg0,
-            case SpaceLeft1 + PreservedOptRRBinSize - BodySize of
+            case SpaceLeft0 + PreservedOptRRBinSize - BodySize of
                 SpaceLeft2 when SpaceLeft2 < OptRRBinSize ->
                     Head = build_header(Msg0, false, QC, ANC, AUC, 0),
                     <<Head/binary, Body/binary>>;

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -33,6 +33,7 @@ groups() ->
         {message_encoding, [parallel], [
             encode_message_max_size,
             encode_message_invalid_size,
+            encode_optrr_kept_near_max_size,
             truncated_query_enforces_opt_record,
             encode_default_message_question_offset_correct,
             encode_default_message_additional_offset_correct
@@ -177,6 +178,39 @@ encode_message_max_size(_) ->
             is_binary(Bin) andalso Msg =:= dns:decode_message(Bin)
         end)
     ].
+
+%% A response close to max_size must still carry the OPT RR when it fits:
+%% 12 B header + 17 B question + 29 x 16 B answers = 493 B, plus the 11 B
+%% OPT RR is 504 B =< 512. Regression for space accounting that subtracted
+%% the question section twice, dropping the OPT RR and additional records
+%% up to question-size bytes before the limit.
+encode_optrr_kept_near_max_size(_) ->
+    Answers = [
+        #dns_rr{
+            name = <<"example.com">>,
+            type = ?DNS_TYPE_A,
+            class = ?DNS_CLASS_IN,
+            ttl = 60,
+            data = #dns_rrdata_a{ip = {192, 0, 2, I}}
+        }
+     || I <- lists:seq(1, 29)
+    ],
+    Msg = #dns_message{
+        id = 1,
+        qr = true,
+        qc = 1,
+        anc = 29,
+        adc = 1,
+        questions = [
+            #dns_query{name = <<"example.com">>, type = ?DNS_TYPE_A, class = ?DNS_CLASS_IN}
+        ],
+        answers = Answers,
+        additional = [#dns_optrr{udp_payload_size = 1232}]
+    },
+    Bin = dns:encode_message(Msg, #{max_size => 512}),
+    ?assert(byte_size(Bin) =< 512),
+    Decoded = dns:decode_message(Bin),
+    ?assertMatch(#dns_message{tc = false, anc = 29, adc = 1, additional = [#dns_optrr{}]}, Decoded).
 
 encode_message_invalid_size(_) ->
     Qs = [#dns_query{name = <<"example">>, type = ?DNS_TYPE_A}],


### PR DESCRIPTION
encode_message_default sized the OPT RR and trailing additional records against SpaceLeft1 + PreservedOptRRBinSize - BodySize. SpaceLeft1 had already subtracted the question-section size, but Body (the accumulator returned by encode_message_d_req) starts from the question bytes, so BodySize subtracts them again. The pool for the OPT RR and additional records was therefore short by the question-section size, and both were dropped from responses within that many bytes of max_size even though they fit. For EDNS responses that meant omitting the OPT RR (contra RFC 6891) while still returning an untruncated answer: a 493-byte response under a 512-byte limit lost its 11-byte OPT RR.

Size the pool from SpaceLeft0 instead, which subtracts the question bytes exactly once via BodySize. The truncated branch already accounted this way (SpaceForOptRR = MaxSize - header - questions).