### PR TITLE
Honour an OPT RR anywhere in the additional section (RFC 6891 §6.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SVCB/HTTPS `mandatory`, `ipv4hint` and `ipv6hint` values that are not a whole number of elements are rejected instead of silently dropping the remainder (RFC 9460 §7.4, §8)
 - An EDNS OPT RR with a non-root owner name, and a message carrying more than one OPT RR, now decode to `formerr` (RFC 6891 §6.1.1)
 - `RDLENGTH = 0` for a type this library decodes now decodes to `formerr` instead of an opaque `<<>>` (RFC 1035 §3.2.1)
+- An OPT RR anywhere but first in the additional section was ignored when sizing the response and dropped from truncated ones (RFC 6891 §6.1.1)
 
 ## v5.0.13
 

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -118,15 +118,24 @@ get_max_size(#{max_size := Value}, _) when
     erlang:error(badarg);
 get_max_size(#{max_size := Value}, _) ->
     Value;
+get_max_size(_, []) ->
+    512;
+%% The OPT is nearly always the first additional record;
+get_max_size(_, [#dns_optrr{} = OptRR | _]) ->
+    optrr_max_size(OptRR);
+get_max_size(_, Additional) ->
+    optrr_max_size(find_optrr(Additional)).
+
+-spec optrr_max_size(dns:optrr() | undefined) -> 512..65535.
 %% A payload size wider than the 16-bit OPT field cannot be encoded at all
-get_max_size(_, [#dns_optrr{udp_payload_size = Value} | _]) when
+optrr_max_size(#dns_optrr{udp_payload_size = Value}) when
     not is_integer(Value) orelse 65535 < Value
 ->
     erlang:error(badarg);
 %% RFC6891§6.2.3: "Values lower than 512 MUST be treated as equal to 512."
-get_max_size(_, [#dns_optrr{udp_payload_size = Value} | _]) ->
+optrr_max_size(#dns_optrr{udp_payload_size = Value}) ->
     max(512, Value);
-get_max_size(_, _) ->
+optrr_max_size(undefined) ->
     512.
 
 -spec encode_message_default(dns:message(), number()) -> binary().
@@ -266,8 +275,26 @@ encode_message_d_opt(Pos, SpaceLeft, CompMap, Recs, Acc) ->
 -spec append_optrr(binary(), dns:additional()) -> {binary(), dns:additional()}.
 append_optrr(Acc, [#dns_optrr{} = OptRR | Rest]) ->
     {encode_optrr(Acc, OptRR), Rest};
-append_optrr(Acc, Other) ->
-    {Acc, Other}.
+append_optrr(Acc, []) ->
+    {Acc, []};
+append_optrr(Acc, [RR | Rest]) ->
+    case take_optrr(Rest, [RR]) of
+        {undefined, Additional} -> {Acc, Additional};
+        {OptRR, Additional} -> {encode_optrr(Acc, OptRR), Additional}
+    end.
+
+%% RFC6891§6.1.1: the OPT RR "MAY be placed anywhere within the additional data section",
+-spec find_optrr(dns:additional()) -> dns:optrr() | undefined.
+find_optrr([#dns_optrr{} = OptRR | _]) -> OptRR;
+find_optrr([_ | Rest]) -> find_optrr(Rest);
+find_optrr([]) -> undefined.
+
+%% Lifts the OPT out, keeping the order of the records around it.
+-spec take_optrr(dns:additional(), [dns:optrr() | dns:rr(), ...]) ->
+    {dns:optrr() | undefined, dns:additional()}.
+take_optrr([#dns_optrr{} = OptRR | Rest], Acc) -> {OptRR, lists:reverse(Acc, Rest)};
+take_optrr([RR | Rest], Acc) -> take_optrr(Rest, [RR | Acc]);
+take_optrr([], Acc) -> {undefined, lists:reverse(Acc)}.
 
 -spec encode_message_axfr(dns:message(), number()) -> binary() | {binary(), dns:message()}.
 encode_message_axfr(#dns_message{} = Msg, MaxSize) ->
@@ -504,18 +531,30 @@ encode_message_rec_unbounded(
     encode_rrdata_append(Acc1, byte_size(Acc1) + 2, C, D, CompMap0).
 
 -spec ensure_optrr(dns:additional(), minimal | full) -> {0 | 1, binary()}.
-ensure_optrr([#dns_optrr{} = OptRR | _], full) ->
-    {1, encode_optrr(<<>>, OptRR)};
-ensure_optrr([#dns_optrr{} = OptRR | _], minimal) ->
-    {1, encode_optrr(<<>>, OptRR#dns_optrr{data = []})};
-ensure_optrr(_, _) ->
-    {0, <<>>}.
+ensure_optrr([#dns_optrr{} = OptRR | _], Mode) ->
+    {1, encode_optrr_mode(OptRR, Mode)};
+ensure_optrr([], _) ->
+    {0, <<>>};
+ensure_optrr(Additional, Mode) ->
+    case find_optrr(Additional) of
+        undefined -> {0, <<>>};
+        #dns_optrr{} = OptRR -> {1, encode_optrr_mode(OptRR, Mode)}
+    end.
+
+-spec encode_optrr_mode(dns:optrr(), minimal | full) -> binary().
+encode_optrr_mode(OptRR, full) -> encode_optrr(<<>>, OptRR);
+encode_optrr_mode(OptRR, minimal) -> encode_optrr(<<>>, OptRR#dns_optrr{data = []}).
 
 -spec preserve_optrr_size(dns:additional()) -> non_neg_integer().
+preserve_optrr_size([]) ->
+    0;
 preserve_optrr_size([#dns_optrr{} | _]) ->
     ?OPTRR_MIN_SIZE;
-preserve_optrr_size(_) ->
-    0.
+preserve_optrr_size(Additional) ->
+    case find_optrr(Additional) of
+        undefined -> 0;
+        #dns_optrr{} -> ?OPTRR_MIN_SIZE
+    end.
 
 -spec encode_optrr(binary(), dns:optrr()) -> binary().
 encode_optrr(Acc, #dns_optrr{

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -57,6 +57,7 @@ groups() ->
             optrr_too_large,
             bad_optrr_too_large,
             optrr_must_be_root_named_and_singular,
+            optrr_honoured_anywhere_in_additional,
             uri_decode_normalization,
             uri_decode_invalid_error,
             decode_encode_rrdata_wire_samples,
@@ -1368,6 +1369,120 @@ optrr_must_be_root_named_and_singular(_) ->
         #dns_message{additional = [#dns_optrr{}, #dns_rr{type = ?DNS_TYPE_A}]},
         dns:decode_message(<<(Header(2))/binary, RootOpt/binary, PlainRR/binary>>)
     ).
+
+%% RFC6891§6.1.1: the OPT RR "MAY be placed anywhere within the additional data
+%% section". The encoder matched it only at the head, so an OPT sitting anywhere
+%% else was invisible to the payload-size lookup and to the space reserved for
+%% it, and was dropped from truncated responses -- contra the same section's
+%% requirement that a response carry an OPT whenever the request did. The
+%% decoder preserves wire order, so [A, OPT] is exactly what a caller gets for a
+%% legal query.
+optrr_honoured_anywhere_in_additional(_) ->
+    Answers = [
+        #dns_rr{
+            name = <<"h", (integer_to_binary(N))/binary, ".example.com">>,
+            type = ?DNS_TYPE_TXT,
+            class = ?DNS_CLASS_IN,
+            ttl = 300,
+            data = #dns_rrdata_txt{txt = [binary:copy(<<$x>>, 200)]}
+        }
+     || N <- lists:seq(1, 20)
+    ],
+    ARR = #dns_rr{
+        name = <<"ns.example.com">>,
+        type = ?DNS_TYPE_A,
+        class = ?DNS_CLASS_IN,
+        ttl = 300,
+        data = #dns_rrdata_a{ip = {192, 0, 2, 1}}
+    },
+    Msg = fun(Additional) ->
+        #dns_message{
+            id = 1,
+            qc = 1,
+            questions = [
+                #dns_query{name = <<"example.com">>, type = ?DNS_TYPE_TXT, class = ?DNS_CLASS_IN}
+            ],
+            anc = length(Answers),
+            answers = Answers,
+            adc = length(Additional),
+            additional = Additional
+        }
+    end,
+    Encode = fun(Additional, Opts) ->
+        case dns:encode_message(Msg(Additional), Opts) of
+            {truncated, Bin, _} -> Bin;
+            Bin when is_binary(Bin) -> Bin
+        end
+    end,
+    HasOpt = fun(Bin) ->
+        #dns_message{additional = Ad} = dns:decode_message(Bin),
+        lists:any(
+            fun
+                (#dns_optrr{}) -> true;
+                (_) -> false
+            end,
+            Ad
+        )
+    end,
+    Opt = #dns_optrr{udp_payload_size = 1232},
+
+    %% A truncated response must carry the OPT wherever it sat in the request
+    [
+        ?assert(HasOpt(Encode(Additional, #{max_size => 512})), Label)
+     || {Label, Additional} <- [
+            {"[OPT]", [Opt]},
+            {"[A, OPT]", [ARR, Opt]},
+            {"[A, A, OPT]", [ARR, ARR, Opt]}
+        ]
+    ],
+    %% The advertised payload size is honoured from any position: a non-head OPT
+    %% used to fall back to the 512 default and truncate harder
+    Big = #dns_optrr{udp_payload_size = 4096},
+    ?assertEqual(
+        byte_size(Encode([Big], #{})),
+        byte_size(Encode([ARR, Big], #{})),
+        "advertised payload size must not depend on OPT position"
+    ),
+    %% ... including the RFC6891§6.2.3 clamp
+    Small = #dns_optrr{udp_payload_size = 0},
+    ?assert(byte_size(Encode([ARR, Small], #{})) =< 512),
+
+    %% The OPT is emitted first, which the placement flexibility allows, and a
+    %% trailing TSIG stays last as RFC2845§3.2 requires
+    TSIG = #dns_rr{
+        name = <<"key.name">>,
+        type = ?DNS_TYPE_TSIG,
+        class = ?DNS_CLASS_ANY,
+        ttl = 0,
+        data = #dns_rrdata_tsig{
+            alg = <<"hmac-sha256">>,
+            time = 0,
+            fudge = 300,
+            mac = <<0:256>>,
+            msgid = 1,
+            err = 0,
+            other = <<>>
+        }
+    },
+    Roomy = #{max_size => 65535},
+    Shape = fun(Additional) ->
+        #dns_message{additional = Ad} = dns:decode_message(Encode(Additional, Roomy)),
+        [
+            case R of
+                #dns_optrr{} -> opt;
+                #dns_rr{type = ?DNS_TYPE_TSIG} -> tsig;
+                #dns_rr{} -> rr
+            end
+         || R <- Ad
+        ]
+    end,
+    ?assertEqual([opt, rr], Shape([ARR, Opt])),
+    ?assertEqual([opt, rr], Shape([Opt, ARR])),
+    ?assertEqual([opt, rr, tsig], Shape([ARR, Opt, TSIG])),
+    ?assertEqual([opt, rr, tsig], Shape([Opt, ARR, TSIG])),
+    %% Without an OPT nothing is reordered, and no space is reserved
+    ?assertEqual([rr, tsig], Shape([ARR, TSIG])),
+    ?assertNot(HasOpt(Encode([ARR], #{max_size => 512}))).
 
 %% RFC3403§4.1: the NAPTR REGEXP field is UTF-8. unicode:characters_to_binary/2
 %% reports invalid input by returning an error tuple instead of raising, so the


### PR DESCRIPTION
RFC 6891 §6.1.1: the OPT RR "MAY be placed anywhere within the additional data section". Four places in the encoder matched it only at the head of that list -- get_max_size/2, preserve_optrr_size/1, ensure_optrr/2 and append_optrr/2 -- so an OPT in any other position was invisible to all of them, with two consequences:

  - Truncated responses dropped the OPT entirely, contra the same section's requirement that a responder include an OPT whenever the request carried one. Reserving space for it was skipped too, since preserve_optrr_size/1 returned 0.
  - The advertised payload size was ignored, falling back to the 512 default, so a client offering a 4096-byte buffer got needlessly truncated answers.

Neither shows up in ordinary traffic, because clients usually put the OPT first -- but nothing requires it, and our own decoder preserves wire order, so [A, OPT] is exactly what a caller is handed for a legal query. It also cannot be last when TSIG or SIG(0) is present, since those must be the final RR.

Each of the four keeps its head match as a fast path and falls back to a scan only when the OPT is elsewhere, so the common case costs exactly what it did before: 500k encodes of a small response measured 496ms/543ms/684ms for additional = []/[OPT]/[A,OPT] against 523ms/544ms/711ms before, i.e. at parity within the ~5% noise this corpus carries. Two rejected alternatives, both measured: threading one lookup through the default path instead of three head matches cost ~5% more, because it traded three allocation-free matches for a scan plus a tuple; and lists:keyfind/3, though a BIF, ran ~2.3x slower than the open-coded loop on [] and [OPT], only overtaking it past roughly ten records -- far longer than any real additional section.