### PR TITLE
Wire-format fidelity: six RDATA bugs, and a property suite that finds them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RDLENGTH = 0` for a type this library decodes now decodes to `formerr` instead of an opaque `<<>>` (RFC 1035 §3.2.1)
 - An OPT RR anywhere but first in the additional section was ignored when sizing the response and dropped from truncated ones (RFC 6891 §6.1.1)
 - URI targets were replaced by their normalized form when decoding, losing data and changing the canonical RDATA that RRSIGs cover (RFC 7553 §4.5)
+- A DNSKEY or CDNSKEY with a DSA algorithm but rdata too short to parse as one crashed on re-encode (RFC 2536 §2)
 
 ## v5.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An EDNS OPT RR with a non-root owner name, and a message carrying more than one OPT RR, now decode to `formerr` (RFC 6891 §6.1.1)
 - `RDLENGTH = 0` for a type this library decodes now decodes to `formerr` instead of an opaque `<<>>` (RFC 1035 §3.2.1)
 - An OPT RR anywhere but first in the additional section was ignored when sizing the response and dropped from truncated ones (RFC 6891 §6.1.1)
+- URI targets were replaced by their normalized form when decoding, losing data and changing the canonical RDATA that RRSIGs cover (RFC 7553 §4.5)
 
 ## v5.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - URI targets were replaced by their normalized form when decoding, losing data and changing the canonical RDATA that RRSIGs cover (RFC 7553 §4.5)
 - A DNSKEY or CDNSKEY with a DSA algorithm but rdata too short to parse as one crashed on re-encode (RFC 2536 §2)
 - Re-encoding a DSA DNSKEY whose P began with a zero byte truncated G and Y, producing an undecodable record (RFC 2536 §2)
+- `encode_rrdata/2` crashed with `badmap` on every KX record, and with it the DNSSEC canonical form (RFC 2230)
+- A repeated or out-of-order NSEC/NSEC3/CSYNC type-bitmap window decoded to a types list containing duplicates (RFC 4034 §4.1.2)
+- LOC precision octets with a base nibble above nine were accepted instead of being left opaque (RFC 1876 §2)
 
 ## v5.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An OPT RR anywhere but first in the additional section was ignored when sizing the response and dropped from truncated ones (RFC 6891 §6.1.1)
 - URI targets were replaced by their normalized form when decoding, losing data and changing the canonical RDATA that RRSIGs cover (RFC 7553 §4.5)
 - A DNSKEY or CDNSKEY with a DSA algorithm but rdata too short to parse as one crashed on re-encode (RFC 2536 §2)
+- Re-encoding a DSA DNSKEY whose P began with a zero byte truncated G and Y, producing an undecodable record (RFC 2536 §2)
 
 ## v5.0.13
 

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -537,14 +537,16 @@ decode_rrdata(
     ?DNS_TYPE_URI,
     <<Priority:16, Weight:16, Target/binary>>
 ) ->
+    %% RFC7553§4.5: validated as a URI but stored verbatim; normalizing the target
+    %% changed the canonical RDATA an RRSIG covers.
     case uri_string:normalize(Target) of
         {error, Reason, _} ->
             erlang:error({bad_uri, Target, Reason});
-        NormalizedTarget ->
+        _Normalized ->
             #dns_rrdata_uri{
                 priority = Priority,
                 weight = Weight,
-                target = NormalizedTarget
+                target = Target
             }
     end;
 decode_rrdata(_MsgBin, Class, ?DNS_TYPE_RESINFO, Bin) when ?CLASS_IS_IN(Class) ->

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -781,7 +781,11 @@ decode_rrdata(
     _Class,
     ?DNS_TYPE_LOC,
     <<0:8, SizeB:4, SizeE:4, HorizB:4, HorizE:4, VertB:4, VertE:4, LatPre:32, LonPre:32, AltPre:32>>
-) when SizeE < 10 andalso HorizE < 10 andalso VertE < 10 ->
+) when
+    %% RFC1876§2: both nibbles are 0..9; only the exponents used to be checked
+    SizeB < 10 andalso HorizB < 10 andalso VertB < 10 andalso
+        SizeE < 10 andalso HorizE < 10 andalso VertE < 10
+->
     #dns_rrdata_loc{
         size = SizeB * (round_pow(SizeE)),
         horiz = HorizB * (round_pow(HorizE)),
@@ -1117,15 +1121,21 @@ decode_loc_point(P) when is_integer(P) ->
 
 -spec decode_nsec_types(binary()) -> [non_neg_integer()].
 decode_nsec_types(Bin) ->
-    do_decode_nsec_types(Bin, []).
+    do_decode_nsec_types(Bin, -1, []).
 
--spec do_decode_nsec_types(binary(), [non_neg_integer()]) -> [non_neg_integer()].
-do_decode_nsec_types(<<>>, Types) ->
+%% RFC4034§4.1.2: window blocks come in increasing order; a repeat let the same
+%% type be counted twice, decoding to a types list with a duplicate in it.
+-spec do_decode_nsec_types(binary(), integer(), [non_neg_integer()]) -> [non_neg_integer()].
+do_decode_nsec_types(<<>>, _PrevWindow, Types) ->
     lists:reverse(Types);
-do_decode_nsec_types(<<WindowNum:8, BMPLength:8, BMP:BMPLength/binary, Rest/binary>>, Types) ->
+do_decode_nsec_types(
+    <<WindowNum:8, BMPLength:8, BMP:BMPLength/binary, Rest/binary>>, PrevWindow, Types
+) when PrevWindow < WindowNum ->
     BaseNo = WindowNum * 256,
     NewTypes = decode_bmp_bytes(BMP, BaseNo, Types),
-    do_decode_nsec_types(Rest, NewTypes).
+    do_decode_nsec_types(Rest, WindowNum, NewTypes);
+do_decode_nsec_types(<<_WindowNum:8, _BMPLength:8, _/binary>>, _PrevWindow, _Types) ->
+    error(bad_nsec_type_bitmap).
 
 -spec decode_bmp_bytes(binary(), non_neg_integer(), [non_neg_integer()]) ->
     [non_neg_integer()].

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -1559,9 +1559,23 @@ encode_dsa_key(PKM) ->
         end
      || X <- PKM
     ],
-    M = byte_size(strip_leading_zeros(binary:encode_unsigned(P))),
-    T = (M - 64) div 8,
-    <<T, Q:20/unit:8, P:M/unit:8, G:M/unit:8, Y:M/unit:8>>.
+    %% RFC2536§2: P, G and Y share one width 64 + 8T; taking it from P alone
+    %% truncated a wider G or Y.
+    S = dsa_field_size(lists:max([unsigned_size(P), unsigned_size(G), unsigned_size(Y)])),
+    T = (S - 64) div 8,
+    QSize = unsigned_size(Q),
+    QSize =< 20 orelse erlang:error(badarg, [Q]),
+    <<T, Q:20/unit:8, P:S/unit:8, G:S/unit:8, Y:S/unit:8>>.
+
+-spec unsigned_size(non_neg_integer()) -> pos_integer().
+unsigned_size(I) ->
+    byte_size(strip_leading_zeros(binary:encode_unsigned(I))).
+
+%% Round up to the next 64 + 8T with T in 0..8; anything wider is unencodable
+-spec dsa_field_size(pos_integer()) -> 64..128.
+dsa_field_size(Bytes) when Bytes =< 64 -> 64;
+dsa_field_size(Bytes) when Bytes =< 128 -> 64 + 8 * ((Bytes - 64 + 7) div 8);
+dsa_field_size(Bytes) -> erlang:error(badarg, [Bytes]).
 
 %% Encodes a character-string as in RFC1035§3.3
 %%

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -723,8 +723,7 @@ encode_rrdata_append(
     },
     CompMap
 ) when
-    Alg =:= ?DNS_ALG_DSA orelse
-        Alg =:= ?DNS_ALG_NSEC3DSA
+    (Alg =:= ?DNS_ALG_DSA orelse Alg =:= ?DNS_ALG_NSEC3DSA) andalso is_list(PKM)
 ->
     PKBin = encode_dsa_key(PKM),
     {<<Acc/binary, (4 + byte_size(PKBin)):16, Flags:16, Protocol:8, Alg:8, PKBin/binary>>, CompMap};
@@ -790,8 +789,7 @@ encode_rrdata_append(
     },
     CompMap
 ) when
-    Alg =:= ?DNS_ALG_DSA orelse
-        Alg =:= ?DNS_ALG_NSEC3DSA
+    (Alg =:= ?DNS_ALG_DSA orelse Alg =:= ?DNS_ALG_NSEC3DSA) andalso is_list(PKM)
 ->
     PKBin = encode_dsa_key(PKM),
     {<<Acc/binary, (4 + byte_size(PKBin)):16, Flags:16, Protocol:8, Alg:8, PKBin/binary>>, CompMap};
@@ -1549,7 +1547,8 @@ encode_rsa_key(E, M) ->
             erlang:error(badarg)
     end.
 
-%% Helper function to encode DSA keys for DNSKEY and CDNSKEY records
+%% Helper function to encode DSA keys for DNSKEY and CDNSKEY records.
+%% Only reachable with the [P, Q, G, Y] list (RFC2536§2); an opaque key is emitted verbatim.
 -spec encode_dsa_key(list()) -> binary().
 encode_dsa_key(PKM) ->
     [P, Q, G, Y] = [

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -970,7 +970,9 @@ encode_rrdata_append(
     #dns_rrdata_kx{preference = Pref, exchange = Name},
     CompMap
 ) ->
-    {Wire, NewCompMap} = dns_domain:to_wire(CompMap, Pos + 2, Name),
+    %% Via encode_dname/3: encode_rrdata/2 passes no compmap, which only the
+    %% wrapper tolerates -- to_wire/3 crashed with badmap on every KX record.
+    {Wire, NewCompMap} = encode_dname(CompMap, Pos + 2, Name),
     {<<Acc/binary, (2 + byte_size(Wire)):16, Pref:16, Wire/binary>>, NewCompMap};
 encode_rrdata_append(
     Acc,

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -22,7 +22,14 @@ groups() ->
             {group, svcb},
             {group, dname_utilities},
             {group, dname_compression},
-            {group, decode_query}
+            {group, decode_query},
+            {group, wire_properties}
+        ]},
+        {wire_properties, [parallel], [
+            prop_rrdata_wire_fidelity,
+            prop_rrdata_reencode_preserves_value,
+            prop_rrdata_reencode_idempotent,
+            prop_rrdata_encode_never_raises
         ]},
         {message_basic, [parallel], [
             message_empty,
@@ -3090,3 +3097,32 @@ encode_multiple_soa_records_compression(_) ->
 split_binary_into_chunks(Bin, Chunk) ->
     List = binary_to_list(Bin),
     [iolist_to_binary(lists:sublist(List, X, Chunk)) || X <- lists:seq(1, length(List), Chunk)].
+
+%% ============================================================================
+%% Wire-format properties (see dns_wire_prop)
+%% ============================================================================
+
+prop_rrdata_wire_fidelity(_) ->
+    run_prop(?FUNCTION_NAME, dns_wire_prop:prop_rrdata_wire_fidelity(), 5000).
+
+prop_rrdata_reencode_preserves_value(_) ->
+    run_prop(?FUNCTION_NAME, dns_wire_prop:prop_rrdata_reencode_preserves_value(), 5000).
+
+prop_rrdata_reencode_idempotent(_) ->
+    run_prop(?FUNCTION_NAME, dns_wire_prop:prop_rrdata_reencode_idempotent(), 5000).
+
+run_prop(PropName, Property, NumTests) ->
+    Opts = [
+        quiet,
+        long_result,
+        {start_size, 2},
+        {numtests, NumTests},
+        {numworkers, erlang:system_info(schedulers_online)}
+    ],
+    case proper:quickcheck(proper:conjunction([{PropName, Property}]), Opts) of
+        true -> ok;
+        Res -> ct:fail(Res)
+    end.
+
+prop_rrdata_encode_never_raises(_) ->
+    run_prop(?FUNCTION_NAME, dns_wire_prop:prop_rrdata_encode_never_raises(), 5000).

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -59,6 +59,7 @@ groups() ->
             optrr_must_be_root_named_and_singular,
             optrr_honoured_anywhere_in_additional,
             dnskey_dsa_alg_short_rdata_reencodes,
+            dnskey_dsa_field_width_preserved,
             uri_decode_preserves_target,
             uri_decode_invalid_error,
             decode_encode_rrdata_wire_samples,
@@ -1370,6 +1371,82 @@ optrr_must_be_root_named_and_singular(_) ->
         #dns_message{additional = [#dns_optrr{}, #dns_rr{type = ?DNS_TYPE_A}]},
         dns:decode_message(<<(Header(2))/binary, RootOpt/binary, PlainRR/binary>>)
     ).
+
+%% RFC2536§2 gives P, G and Y one shared width S = 64 + 8T, T in 0..8, with T on
+%% the wire but absent from the record, so encoding has to derive it. It derived
+%% it from P alone and did not round to that lattice, so a valid key whose P
+%% merely began with a zero byte re-encoded three bytes short with G and Y
+%% truncated -- a record no decoder could parse.
+dnskey_dsa_field_width_preserved(_) ->
+    Key = fun(T, PTop, GTop, YTop) ->
+        S = 64 + T * 8,
+        Fill = fun(Top, Byte) -> <<Top, (binary:copy(<<Byte>>, S - 1))/binary>> end,
+        Q = binary:copy(<<16#DD>>, 20),
+        <<256:16, 3:8, (?DNS_ALG_DSA):8, T, Q/binary, (Fill(PTop, 16#AA))/binary,
+            (Fill(GTop, 16#BB))/binary, (Fill(YTop, 16#CC))/binary>>
+    end,
+    Decode = fun(Wire) -> dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_DNSKEY, Wire) end,
+    %% Whenever the widest field pins the width, the wire form is reproduced exactly
+    [
+        begin
+            Wire = Key(T, PTop, GTop, 16#CC),
+            Decoded = Decode(Wire),
+            ?assertMatch(#dns_rrdata_dnskey{public_key = [_, _, _, _]}, Decoded, {T, PTop}),
+            ?assertEqual(Wire, dns_encode:encode_rrdata(?DNS_CLASS_IN, Decoded), {T, PTop, GTop})
+        end
+     || {T, PTop, GTop} <- [
+            {0, 16#AA, 16#BB},
+            %% P starting with a zero byte was the corrupting case
+            {0, 16#00, 16#BB},
+            {1, 16#00, 16#BB},
+            {0, 16#00, 16#00},
+            {8, 16#00, 16#00}
+        ]
+    ],
+    %% When every field has leading zeros the original T cannot be recovered, since
+    %% the record does not carry it. The result must still be a valid, decodable
+    %% record with the same key values -- just at the minimal width.
+    Narrow = <<
+        256:16,
+        3:8,
+        (?DNS_ALG_DSA):8,
+        1,
+        (binary:copy(<<16#DD>>, 20))/binary,
+        %% T=1 means 72-byte fields, but each value fits 64 bytes
+        (binary:copy(<<0>>, 8))/binary,
+        (binary:copy(<<16#AA>>, 64))/binary,
+        (binary:copy(<<0>>, 8))/binary,
+        (binary:copy(<<16#BB>>, 64))/binary,
+        (binary:copy(<<0>>, 8))/binary,
+        (binary:copy(<<16#CC>>, 64))/binary
+    >>,
+    NarrowDecoded = Decode(Narrow),
+    Reencoded = dns_encode:encode_rrdata(?DNS_CLASS_IN, NarrowDecoded),
+    ?assertNotEqual(Narrow, Reencoded),
+    ?assertEqual(
+        NarrowDecoded#dns_rrdata_dnskey.public_key,
+        (Decode(Reencoded))#dns_rrdata_dnskey.public_key
+    ),
+    %% Values too wide for the field, or a Q past its fixed 20 bytes, are rejected
+    %% rather than silently truncated
+    Wide = fun(Field, Bytes) ->
+        Big = binary:decode_unsigned(binary:copy(<<16#FF>>, Bytes)),
+        Ok = binary:decode_unsigned(binary:copy(<<16#AA>>, 64)),
+        Q = binary:decode_unsigned(binary:copy(<<16#DD>>, 20)),
+        PK =
+            case Field of
+                p -> [Big, Q, Ok, Ok];
+                g -> [Ok, Q, Big, Ok];
+                y -> [Ok, Q, Ok, Big];
+                q -> [Ok, Big, Ok, Ok]
+            end,
+        #dns_rrdata_dnskey{flags = 256, protocol = 3, alg = ?DNS_ALG_DSA, public_key = PK}
+    end,
+    [
+        ?assertError(badarg, dns_encode:encode_rrdata(?DNS_CLASS_IN, Wide(F, 129)), F)
+     || F <- [p, g, y]
+    ],
+    ?assertError(badarg, dns_encode:encode_rrdata(?DNS_CLASS_IN, Wide(q, 21))).
 
 %% RFC2536§2 lays a DSA DNSKEY out as T, Q, P, G, Y, so rdata shorter than that
 %% cannot be parsed as one and decodes through the generic clause, leaving

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -58,6 +58,7 @@ groups() ->
             bad_optrr_too_large,
             optrr_must_be_root_named_and_singular,
             optrr_honoured_anywhere_in_additional,
+            dnskey_dsa_alg_short_rdata_reencodes,
             uri_decode_preserves_target,
             uri_decode_invalid_error,
             decode_encode_rrdata_wire_samples,
@@ -1368,6 +1369,57 @@ optrr_must_be_root_named_and_singular(_) ->
     ?assertMatch(
         #dns_message{additional = [#dns_optrr{}, #dns_rr{type = ?DNS_TYPE_A}]},
         dns:decode_message(<<(Header(2))/binary, RootOpt/binary, PlainRR/binary>>)
+    ).
+
+%% RFC2536§2 lays a DSA DNSKEY out as T, Q, P, G, Y, so rdata shorter than that
+%% cannot be parsed as one and decodes through the generic clause, leaving
+%% public_key a binary. The DSA encode clause matched a bare variable guarded only
+%% on the algorithm, so that binary reached encode_dsa_key/1 and died in a list
+%% comprehension: one crafted rdata made decode succeed and re-encode crash, which
+%% is reachable by anything that decodes then re-encodes.
+dnskey_dsa_alg_short_rdata_reencodes(_) ->
+    DsaAlgs = [?DNS_ALG_DSA, ?DNS_ALG_NSEC3DSA],
+    Short = fun(Alg) -> <<256:16, 3:8, Alg:8, 1, 2, 3, 4, 5, 6, 7, 8>> end,
+    [
+        begin
+            Rdata = Short(Alg),
+            Data = dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, Type, Rdata),
+            %% too short for the DSA layout, so the key stays opaque ...
+            PK =
+                case Type of
+                    ?DNS_TYPE_DNSKEY -> Data#dns_rrdata_dnskey.public_key;
+                    ?DNS_TYPE_CDNSKEY -> Data#dns_rrdata_cdnskey.public_key
+                end,
+            ?assert(is_binary(PK), {Type, Alg}),
+            %% ... and re-encoding reproduces the original bytes instead of crashing
+            ?assertEqual(Rdata, dns_encode:encode_rrdata(?DNS_CLASS_IN, Data), {Type, Alg})
+        end
+     || Type <- [?DNS_TYPE_DNSKEY, ?DNS_TYPE_CDNSKEY], Alg <- DsaAlgs
+    ],
+    %% Reachable through a full message: decode then re-encode must both survive
+    Rdata = Short(?DNS_ALG_NSEC3DSA),
+    Header = <<1:16, 1:1, 0:4, 0:1, 0:1, 0:1, 0:1, 0:1, 0:1, 0:1, 0:4, 0:16, 1:16, 0:16, 0:16>>,
+    Answer =
+        <<3, $f, $o, $o, 0, (?DNS_TYPE_DNSKEY):16, (?DNS_CLASS_IN):16, 300:32,
+            (byte_size(Rdata)):16, Rdata/binary>>,
+    Wire = <<Header/binary, Answer/binary>>,
+    Decoded = dns:decode_message(Wire),
+    ?assertMatch(#dns_message{}, Decoded),
+    ?assertEqual(Wire, dns:encode_message(Decoded)),
+
+    %% A well-formed DSA key still takes the DSA path and round-trips
+    Q = 16#7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+    P = binary:decode_unsigned(binary:copy(<<16#FF>>, 64)),
+    WellFormed = #dns_rrdata_dnskey{
+        flags = 256,
+        protocol = 3,
+        alg = ?DNS_ALG_DSA,
+        public_key = [P, Q, P, P]
+    },
+    DsaWire = dns_encode:encode_rrdata(?DNS_CLASS_IN, WellFormed),
+    ?assertMatch(
+        #dns_rrdata_dnskey{alg = ?DNS_ALG_DSA, public_key = [_, _, _, _]},
+        dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_DNSKEY, DsaWire)
     ).
 
 %% RFC6891§6.1.1: the OPT RR "MAY be placed anywhere within the additional data

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -58,7 +58,7 @@ groups() ->
             bad_optrr_too_large,
             optrr_must_be_root_named_and_singular,
             optrr_honoured_anywhere_in_additional,
-            uri_decode_normalization,
+            uri_decode_preserves_target,
             uri_decode_invalid_error,
             decode_encode_rrdata_wire_samples,
             decode_encode_rrdata,
@@ -1602,46 +1602,44 @@ decode_minfo_in_message(_) ->
     Decoded = dns:decode_message(dns:encode_message(Msg)),
     ?assertMatch(#dns_message{answers = [#dns_rr{data = Rdata}]}, Decoded).
 
-uri_decode_normalization(_) ->
-    %% Test that URI targets are normalized during decoding
-    Cases = [
-        %% {Input URI, Expected normalized URI}
-        {<<"HTTPS://EXAMPLE.COM/">>, <<"https://example.com/">>},
-        {<<"http://example.com/path">>, <<"http://example.com/path">>},
-        {<<"https://www.example.com/">>, <<"https://www.example.com/">>},
-        {<<"HTTPS://EXAMPLE.COM:443/">>, <<"https://example.com/">>}
+%% RFC7553§4.5: the target is a URI. It used to be replaced by
+%% uri_string:normalize/1 during decoding, which lost a default port, the case of
+%% the host, percent-escapes and dot segments -- and, since dnssec builds
+%% signature input by re-encoding decoded records, silently changed the canonical
+%% RDATA an RRSIG covers, so a signature made elsewhere over an unnormalized
+%% target could not verify here. Decoding now preserves the bytes exactly.
+uri_decode_preserves_target(_) ->
+    Targets = [
+        <<"https://example.com/">>,
+        <<"HTTPS://EXAMPLE.COM/">>,
+        <<"HTTPS://EXAMPLE.COM:443/">>,
+        <<"https://example.com/a/../b">>,
+        <<"ftp://x/%7Euser">>,
+        <<"http://example.com/path">>,
+        <<"https://example.com:8443/x?q=1#f">>
     ],
     [
         begin
-            %% Encode the URI record
-            Priority = 10,
-            Weight = 1,
-            Rdata = #dns_rrdata_uri{
-                priority = Priority,
-                weight = Weight,
-                target = InputURI
-            },
-            {Encoded, _} = dns_encode:encode_rrdata(0, ?DNS_CLASS_IN, Rdata, #{}),
-
-            %% Decode and verify normalization
-            Decoded = dns_decode:decode_rrdata(Encoded, ?DNS_CLASS_IN, ?DNS_TYPE_URI, Encoded),
-            #dns_rrdata_uri{
-                priority = DecodedPriority,
-                weight = DecodedWeight,
-                target = DecodedTarget
-            } = Decoded,
-            ?assertEqual(Priority, DecodedPriority),
-            ?assertEqual(Weight, DecodedWeight),
-            ?assertEqual(
-                ExpectedNormalized,
-                DecodedTarget,
-                io_lib:format(
-                    "URI normalization failed: ~p -> ~p (expected ~p)",
-                    [InputURI, DecodedTarget, ExpectedNormalized]
-                )
-            )
+            Wire = <<10:16, 1:16, Target/binary>>,
+            Decoded = dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_URI, Wire),
+            ?assertMatch(#dns_rrdata_uri{priority = 10, weight = 1}, Decoded, Target),
+            ?assertEqual(Target, Decoded#dns_rrdata_uri.target, Target),
+            %% ... so the wire form is reproduced byte for byte
+            ?assertEqual(Wire, dns_encode:encode_rrdata(?DNS_CLASS_IN, Decoded), Target)
         end
-     || {InputURI, ExpectedNormalized} <- Cases
+     || Target <- Targets
+    ],
+    %% The canonical RDATA dnssec signs over must equal what arrived
+    [
+        begin
+            Wire = <<10:16, 1:16, Target/binary>>,
+            Decoded = dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_URI, Wire),
+            Canonical = dns_encode:encode_rrdata(
+                ?DNS_CLASS_IN, dnssec:canonical_rrdata_form(Decoded)
+            ),
+            ?assertEqual(Wire, Canonical, Target)
+        end
+     || Target <- Targets
     ].
 
 uri_decode_invalid_error(_) ->

--- a/test/dns_wire_prop.erl
+++ b/test/dns_wire_prop.erl
@@ -1,0 +1,632 @@
+%% Wire-format properties for RDATA, the ground the suite left uncovered:
+%% prop_wire_roundtrip in dns_domain_SUITE covers only domain names, and the
+%% encode/decode properties in dns_zone_prop cover the presentation format, so
+%% nothing checked that RDATA survives a trip through the wire codec.
+%%
+%% The input is rdata bytes, not records, because that is what exposes a decoder
+%% that quietly discards part of its input or mints a record the encoder cannot
+%% handle. Of the wire bugs the audit turned up, these catch the URI targets
+%% decoding used to rewrite, the DSA key whose fields were written too narrow, and
+%% the KX record that crashed encode_rrdata/2.
+%%
+%% Two limits are worth knowing, so nobody reads a pass here as more than it is.
+%% An error made symmetrically in both directions is invisible: LOC's reference
+%% point was off by one in encode and decode alike, so every round-trip
+%% succeeded -- only a known-answer vector catches that, which is why
+%% loc_wire_reference_point exists. And rdata seeded by encoding a record cannot
+%% catch the encoder dropping information, since the seed is already missing it;
+%% handbuilt_rdata/0 spells such cases out on the wire instead.
+-module(dns_wire_prop).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("dns_erlang/include/dns.hrl").
+
+%% ============================================================================
+%% Properties
+%% ============================================================================
+
+%% encode(decode(B)) =:= B. The wire form is authoritative: whatever we hand back
+%% must be what arrived, since dnssec builds signature input by re-encoding
+%% decoded records, so any rewrite here changes the bytes an RRSIG covers.
+prop_rrdata_wire_fidelity() ->
+    ?FORALL(
+        {Type, Bin},
+        rdata_case(),
+        case decode(Type, Bin) of
+            skip ->
+                true;
+            {typed, Data} ->
+                case encode(Type, Data) of
+                    {error, _} -> false;
+                    Bin -> true;
+                    Re -> permitted_normalisation(Type, Bin, Re)
+                end
+        end
+    ).
+
+%% Re-encoding must not destroy information: the re-encoded form has to decode
+%% again, to the same value. This is what the DSA key bug violated -- it wrote
+%% fields too narrow for their values, and the result decoded to nothing at all.
+prop_rrdata_reencode_preserves_value() ->
+    ?FORALL(
+        {Type, Bin},
+        rdata_case(),
+        case decode(Type, Bin) of
+            skip ->
+                true;
+            {typed, Data} ->
+                case encode(Type, Data) of
+                    {error, _} -> false;
+                    Re -> decode(Type, Re) =:= {typed, Data}
+                end
+        end
+    ).
+
+%% Whatever normalising a decode does, it must converge after one pass, so that
+%% a record does not keep drifting each time it is relayed.
+prop_rrdata_reencode_idempotent() ->
+    ?FORALL(
+        {Type, Bin},
+        rdata_case(),
+        case decode(Type, Bin) of
+            skip ->
+                true;
+            {typed, Data} ->
+                case encode(Type, Data) of
+                    {error, _} ->
+                        false;
+                    Once ->
+                        case decode(Type, Once) of
+                            {typed, Data2} -> encode(Type, Data2) =:= Once;
+                            _ -> false
+                        end
+                end
+        end
+    ).
+
+%% dns_encode:encode_rrdata/2 is exported and passes no compression map, and
+%% dnssec builds canonical RDATA through it, so it has to handle every record the
+%% codec can produce. A KX record crashed it with badmap, because that clause
+%% reached for the compressing path directly instead of the wrapper that tolerates
+%% a missing map -- invisible when encoding a whole message, where a map exists.
+prop_rrdata_encode_never_raises() ->
+    ?FORALL(
+        Data,
+        rrdata(),
+        case encode(ignored, Data) of
+            {error, _} -> false;
+            Bin -> is_binary(Bin)
+        end
+    ).
+
+%% ============================================================================
+%% Permitted differences
+%% ============================================================================
+
+%% RFC5155§3.1.2: the NSEC3 flags octet defines only Opt-Out; the remaining bits
+%% are reserved and MUST be ignored on receipt, so they are not carried in the
+%% record and cannot be reproduced. Pinned exactly: nothing but those bits moves.
+permitted_normalisation(?DNS_TYPE_NSEC3, <<HashAlg, Flags, Rest/binary>>, Re) ->
+    Re =:= <<HashAlg, (Flags band 2#1), Rest/binary>> orelse
+        dropped_empty_bitmap_block(?DNS_TYPE_NSEC3, <<HashAlg, Flags, Rest/binary>>, Re);
+%% RFC4034§4.1.2: "Blocks with no types present MUST NOT be included", so a block
+%% carrying no types is dropped rather than echoed back.
+permitted_normalisation(Type, Bin, Re) when
+    ?DNS_TYPE_NSEC =:= Type; ?DNS_TYPE_CSYNC =:= Type
+->
+    dropped_empty_bitmap_block(Type, Bin, Re);
+%% RFC2535§5.2: the NXT bitmap is "no longer than necessary", so octets past the
+%% highest type present must not be on the wire and are trimmed rather than echoed.
+permitted_normalisation(?DNS_TYPE_NXT, Bin, Re) ->
+    byte_size(Re) < byte_size(Bin) andalso nxt_types_of(Bin) =:= nxt_types_of(Re);
+%% RFC1876§2: a LOC precision octet is a base times ten to an exponent, so base 0
+%% means zero whatever the exponent -- 0x01 and 0x00 both encode zero, and 0x00 is
+%% the canonical spelling. Deliberately narrow: a whitelist of "anything that
+%% preserves the decoded value" would also have waved through the URI targets that
+%% decoding used to rewrite, since those too decode alike either way.
+permitted_normalisation(
+    ?DNS_TYPE_LOC, <<V, S1, H1, T1, Rest/binary>>, <<V, S2, H2, T2, Rest/binary>>
+) ->
+    redundant_zero(S1, S2) andalso redundant_zero(H1, H2) andalso redundant_zero(T1, T2);
+permitted_normalisation(_Type, _Bin, _Re) ->
+    false.
+
+redundant_zero(Octet, Octet) -> true;
+redundant_zero(In, Out) -> In band 16#F0 =:= 0 andalso Out =:= 16#00.
+
+nxt_types_of(Bin) ->
+    case decode(?DNS_TYPE_NXT, Bin) of
+        {typed, #dns_rrdata_nxt{types = T}} -> T;
+        Other -> Other
+    end.
+
+%% Dropping empty blocks can only shorten the rdata, and must leave the covered
+%% types untouched -- which rules out a corrupted bitmap masquerading as one.
+dropped_empty_bitmap_block(Type, Bin, Re) ->
+    byte_size(Re) < byte_size(Bin) andalso types_of(Type, Bin) =:= types_of(Type, Re).
+
+types_of(Type, Bin) ->
+    case decode(Type, Bin) of
+        {typed, #dns_rrdata_nsec{types = T}} -> T;
+        {typed, #dns_rrdata_nsec3{types = T}} -> T;
+        {typed, #dns_rrdata_csync{types = T}} -> T;
+        Other -> Other
+    end.
+
+%% ============================================================================
+%% Helpers
+%% ============================================================================
+
+%% `skip` covers the two cases with nothing to assert: rdata the decoder rejects,
+%% and rdata it keeps opaque (RFC3597), which is symmetric by construction.
+decode(Type, Bin) ->
+    try dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, Type, Bin) of
+        Data when is_binary(Data) -> skip;
+        Data -> {typed, Data}
+    catch
+        _:_ -> skip
+    end.
+
+encode(_Type, Data) ->
+    try
+        dns_encode:encode_rrdata(?DNS_CLASS_IN, Data)
+    catch
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+%% ============================================================================
+%% Generators
+%% ============================================================================
+
+%% Random bytes alone are useless here: they reach a structured decoder's pattern
+%% almost never (measured over 10k draws -- TXT 0.4%, HINFO 0.06%, SOA 0%), so a
+%% property fed only random bytes passes without testing anything. Seed instead
+%% with rdata built by encoding a generated record, and mutate that, which lands
+%% inside the decoders and still reaches their error paths.
+rdata_case() ->
+    frequency([
+        {4, valid_rdata()},
+        {4, mutated_rdata()},
+        {3, handbuilt_rdata()},
+        {1, random_rdata()}
+    ]).
+
+%% Encoding goes through the protected wrapper: an encoder that raises here would
+%% otherwise kill the whole run during generation instead of failing a property,
+%% which is how the KX crash first showed up. prop_rrdata_encode_never_raises/0
+%% below is what actually holds it to account.
+valid_rdata() ->
+    ?LET(Data, rrdata(), {type_of(Data), safe_encode(Data)}).
+
+safe_encode(Data) ->
+    case encode(ignored, Data) of
+        {error, _} -> <<>>;
+        Bin -> Bin
+    end.
+
+mutated_rdata() ->
+    ?LET(
+        {{Type, Bin}, Mutation}, {valid_rdata(), mutation()}, {Type, apply_mutation(Mutation, Bin)}
+    ).
+
+random_rdata() ->
+    ?LET({Type, Len}, {decodable_type(), integer(0, 48)}, {Type, binary(Len)}).
+
+%% Built as bytes, never by encoding a record. Seeding only from the encoder
+%% cannot catch the encoder dropping information: the seed would already be
+%% missing it and would round-trip happily. The empty <character-string> the
+%% encoder used to discard is exactly that case, so it has to be spelled on the
+%% wire here.
+handbuilt_rdata() ->
+    oneof([
+        ?LET({Type, Strings}, {charstring_type(), wire_charstrings()}, {Type, Strings}),
+        %% HINFO is two character-strings, either of which may be empty
+        ?LET(
+            {A, B},
+            {wire_charstring(), wire_charstring()},
+            {?DNS_TYPE_HINFO, <<A/binary, B/binary>>}
+        )
+    ]).
+
+charstring_type() ->
+    oneof([?DNS_TYPE_TXT, ?DNS_TYPE_SPF, ?DNS_TYPE_RESINFO, ?DNS_TYPE_WALLET]).
+
+wire_charstrings() ->
+    ?LET(L, ?SUCHTHAT(L0, list(wire_charstring()), [] =/= L0), iolist_to_binary(L)).
+
+wire_charstring() ->
+    ?LET(B, bin(0, 6), <<(byte_size(B)), B/binary>>).
+
+%% Every type dns_decode:decode_rrdata/4 has a clause for. Only random_rdata/0
+%% needs this; the record generators carry their own types via type_of/1.
+decodable_type() ->
+    oneof([
+        ?DNS_TYPE_A,
+        ?DNS_TYPE_AAAA,
+        ?DNS_TYPE_AFSDB,
+        ?DNS_TYPE_CAA,
+        ?DNS_TYPE_CDNSKEY,
+        ?DNS_TYPE_CDS,
+        ?DNS_TYPE_CERT,
+        ?DNS_TYPE_CNAME,
+        ?DNS_TYPE_CSYNC,
+        ?DNS_TYPE_DHCID,
+        ?DNS_TYPE_DLV,
+        ?DNS_TYPE_DNAME,
+        ?DNS_TYPE_DNSKEY,
+        ?DNS_TYPE_DS,
+        ?DNS_TYPE_DSYNC,
+        ?DNS_TYPE_EUI48,
+        ?DNS_TYPE_EUI64,
+        ?DNS_TYPE_HINFO,
+        ?DNS_TYPE_HTTPS,
+        ?DNS_TYPE_IPSECKEY,
+        ?DNS_TYPE_KEY,
+        ?DNS_TYPE_KX,
+        ?DNS_TYPE_LOC,
+        ?DNS_TYPE_MB,
+        ?DNS_TYPE_MG,
+        ?DNS_TYPE_MINFO,
+        ?DNS_TYPE_MR,
+        ?DNS_TYPE_MX,
+        ?DNS_TYPE_NAPTR,
+        ?DNS_TYPE_NS,
+        ?DNS_TYPE_NSEC,
+        ?DNS_TYPE_NSEC3,
+        ?DNS_TYPE_NSEC3PARAM,
+        ?DNS_TYPE_NXT,
+        ?DNS_TYPE_OPENPGPKEY,
+        ?DNS_TYPE_PTR,
+        ?DNS_TYPE_RESINFO,
+        ?DNS_TYPE_RP,
+        ?DNS_TYPE_RRSIG,
+        ?DNS_TYPE_RT,
+        ?DNS_TYPE_SMIMEA,
+        ?DNS_TYPE_SOA,
+        ?DNS_TYPE_SPF,
+        ?DNS_TYPE_SRV,
+        ?DNS_TYPE_SSHFP,
+        ?DNS_TYPE_SVCB,
+        ?DNS_TYPE_TLSA,
+        ?DNS_TYPE_TSIG,
+        ?DNS_TYPE_TXT,
+        ?DNS_TYPE_URI,
+        ?DNS_TYPE_WALLET,
+        ?DNS_TYPE_ZONEMD
+    ]).
+
+mutation() ->
+    oneof([{flip, integer(0, 47), integer(0, 255)}, {truncate, integer(1, 8)}, {append, binary(2)}]).
+
+apply_mutation({flip, At, Byte}, Bin) when At < byte_size(Bin) ->
+    <<Head:At/binary, _, Tail/binary>> = Bin,
+    <<Head/binary, Byte, Tail/binary>>;
+apply_mutation({truncate, N}, Bin) when N < byte_size(Bin) ->
+    binary:part(Bin, 0, byte_size(Bin) - N);
+apply_mutation({append, Extra}, Bin) ->
+    <<Bin/binary, Extra/binary>>;
+apply_mutation(_, Bin) ->
+    Bin.
+
+%% ============================================================================
+%% Record generators
+%% ============================================================================
+
+rrdata() ->
+    oneof([
+        #dns_rrdata_a{ip = ip4()},
+        #dns_rrdata_aaaa{ip = ip6()},
+        ?LET({S, H}, {u16(), dname()}, #dns_rrdata_afsdb{subtype = S, hostname = H}),
+        ?LET(
+            {F, T, V},
+            {u8(), bin(1, 15), bin(0, 20)},
+            #dns_rrdata_caa{flags = F, tag = T, value = V}
+        ),
+        ?LET(
+            {T, K, A, C},
+            {u16(), u16(), u8(), bin(0, 20)},
+            #dns_rrdata_cert{type = T, keytag = K, alg = A, cert = C}
+        ),
+        ?LET(N, dname(), #dns_rrdata_cname{dname = N}),
+        ?LET(
+            {S, F, T},
+            {u32(), u16(), types()},
+            #dns_rrdata_csync{soa_serial = S, flags = F, types = T}
+        ),
+        ?LET(B, bin(1, 20), #dns_rrdata_dhcid{data = B}),
+        ?LET(N, dname(), #dns_rrdata_dname{dname = N}),
+        ?LET(
+            {K, A, D, Dg},
+            {u16(), u8(), u8(), bin(1, 20)},
+            #dns_rrdata_ds{keytag = K, alg = A, digest_type = D, digest = Dg}
+        ),
+        ?LET(
+            {K, A, D, Dg},
+            {u16(), u8(), u8(), bin(1, 20)},
+            #dns_rrdata_cds{keytag = K, alg = A, digest_type = D, digest = Dg}
+        ),
+        ?LET(
+            {K, A, D, Dg},
+            {u16(), u8(), u8(), bin(1, 20)},
+            #dns_rrdata_dlv{keytag = K, alg = A, digest_type = D, digest = Dg}
+        ),
+        ?LET(
+            {F, P, A, K},
+            {u16(), u8(), u8(), bin(1, 24)},
+            #dns_rrdata_dnskey{flags = F, protocol = P, alg = A, public_key = K}
+        ),
+        ?LET(
+            {F, P, A, K},
+            {u16(), u8(), u8(), bin(1, 24)},
+            #dns_rrdata_cdnskey{flags = F, protocol = P, alg = A, public_key = K}
+        ),
+        ?LET(
+            {R, S, P, T},
+            {u16(), u8(), u16(), dname()},
+            #dns_rrdata_dsync{rrtype = R, scheme = S, port = P, target = T}
+        ),
+        ?LET(B, bin(6, 6), #dns_rrdata_eui48{address = B}),
+        ?LET(B, bin(8, 8), #dns_rrdata_eui64{address = B}),
+        ?LET({C, O}, {bin(0, 20), bin(0, 20)}, #dns_rrdata_hinfo{cpu = C, os = O}),
+        ?LET({P, T}, {u16(), dname()}, #dns_rrdata_https{
+            svc_priority = P,
+            target_name = T,
+            svc_params = #{}
+        }),
+        ?LET(
+            {P, A, K},
+            {u8(), u8(), bin(1, 20)},
+            #dns_rrdata_ipseckey{precedence = P, alg = A, gateway = <<>>, public_key = K}
+        ),
+        ?LET(
+            {Ty, X, NT, Sg, P, A, K},
+            {integer(0, 3), integer(0, 1), integer(0, 3), integer(0, 15), u8(), u8(), bin(1, 20)},
+            #dns_rrdata_key{
+                type = Ty,
+                xt = X,
+                name_type = NT,
+                sig = Sg,
+                protocol = P,
+                alg = A,
+                public_key = K
+            }
+        ),
+        ?LET({P, E}, {u16(), dname()}, #dns_rrdata_kx{preference = P, exchange = E}),
+        ?LET(
+            {Sz, H, V, La, Lo, Al},
+            {
+                loc_precision(),
+                loc_precision(),
+                loc_precision(),
+                loc_coord(),
+                loc_coord(),
+                integer(-100000, 100000)
+            },
+            #dns_rrdata_loc{size = Sz, horiz = H, vert = V, lat = La, lon = Lo, alt = Al}
+        ),
+        ?LET(N, dname(), #dns_rrdata_mb{madname = N}),
+        ?LET(N, dname(), #dns_rrdata_mg{madname = N}),
+        ?LET({R, E}, {dname(), dname()}, #dns_rrdata_minfo{rmailbx = R, emailbx = E}),
+        ?LET(N, dname(), #dns_rrdata_mr{newname = N}),
+        ?LET({P, E}, {u16(), dname()}, #dns_rrdata_mx{preference = P, exchange = E}),
+        ?LET(
+            {O, P, F, S, R, Rp},
+            {u16(), u16(), bin(0, 4), bin(0, 8), ascii(0, 12), dname()},
+            #dns_rrdata_naptr{
+                order = O,
+                preference = P,
+                flags = F,
+                services = S,
+                regexp = R,
+                replacement = Rp
+            }
+        ),
+        ?LET(N, dname(), #dns_rrdata_ns{dname = N}),
+        ?LET({N, T}, {dname(), types()}, #dns_rrdata_nsec{next_dname = N, types = T}),
+        ?LET(
+            {A, O, I, S, H, T},
+            {u8(), boolean(), u16(), bin(0, 8), bin(1, 20), types()},
+            #dns_rrdata_nsec3{
+                hash_alg = A,
+                opt_out = O,
+                iterations = I,
+                salt = S,
+                hash = H,
+                types = T
+            }
+        ),
+        ?LET(
+            {A, F, I, S},
+            {u8(), u8(), u16(), bin(0, 8)},
+            #dns_rrdata_nsec3param{hash_alg = A, flags = F, iterations = I, salt = S}
+        ),
+        ?LET({N, T}, {dname(), nxt_types()}, #dns_rrdata_nxt{dname = N, types = T}),
+        ?LET(B, bin(1, 20), #dns_rrdata_openpgpkey{data = B}),
+        ?LET(N, dname(), #dns_rrdata_ptr{dname = N}),
+        ?LET(S, charstrings(), #dns_rrdata_resinfo{data = S}),
+        ?LET({M, T}, {dname(), dname()}, #dns_rrdata_rp{mbox = M, txt = T}),
+        ?LET(
+            {Tc, A, L, Ot, Ex, In, K, Sn, Sg},
+            {u16(), u8(), u8(), u32(), u32(), u32(), u16(), dname(), bin(1, 20)},
+            #dns_rrdata_rrsig{
+                type_covered = Tc,
+                alg = A,
+                labels = L,
+                original_ttl = Ot,
+                expiration = Ex,
+                inception = In,
+                keytag = K,
+                signers_name = Sn,
+                signature = Sg
+            }
+        ),
+        ?LET({P, H}, {u16(), dname()}, #dns_rrdata_rt{preference = P, host = H}),
+        ?LET(
+            {U, S, M, C},
+            {u8(), u8(), u8(), bin(1, 20)},
+            #dns_rrdata_smimea{usage = U, selector = S, matching_type = M, certificate = C}
+        ),
+        ?LET(
+            {U, S, M, C},
+            {u8(), u8(), u8(), bin(1, 20)},
+            #dns_rrdata_tlsa{usage = U, selector = S, matching_type = M, certificate = C}
+        ),
+        ?LET(
+            {Mn, Rn, Se, Rf, Rt, Ex, Mi},
+            {dname(), dname(), u32(), u32(), u32(), u32(), u32()},
+            #dns_rrdata_soa{
+                mname = Mn,
+                rname = Rn,
+                serial = Se,
+                refresh = Rf,
+                retry = Rt,
+                expire = Ex,
+                minimum = Mi
+            }
+        ),
+        ?LET(S, charstrings(), #dns_rrdata_spf{spf = S}),
+        ?LET(
+            {P, W, Po, T},
+            {u16(), u16(), u16(), dname()},
+            #dns_rrdata_srv{priority = P, weight = W, port = Po, target = T}
+        ),
+        ?LET(
+            {A, F, Fp},
+            {u8(), u8(), bin(1, 20)},
+            #dns_rrdata_sshfp{alg = A, fp_type = F, fp = Fp}
+        ),
+        ?LET({P, T}, {u16(), dname()}, #dns_rrdata_svcb{
+            svc_priority = P,
+            target_name = T,
+            svc_params = #{}
+        }),
+        ?LET(
+            {A, Ti, F, M, Mi, E, O},
+            {dname(), u48(), u16(), bin(0, 32), u16(), u16(), bin(0, 4)},
+            #dns_rrdata_tsig{
+                alg = A,
+                time = Ti,
+                fudge = F,
+                mac = M,
+                msgid = Mi,
+                err = E,
+                other = O
+            }
+        ),
+        ?LET(S, charstrings(), #dns_rrdata_txt{txt = S}),
+        ?LET({P, W, T}, {u16(), u16(), uri()}, #dns_rrdata_uri{
+            priority = P,
+            weight = W,
+            target = T
+        }),
+        ?LET(S, charstrings(), #dns_rrdata_wallet{data = S}),
+        ?LET(
+            {Se, Sc, A, H},
+            {u32(), u8(), u8(), bin(1, 20)},
+            #dns_rrdata_zonemd{serial = Se, scheme = Sc, algorithm = A, hash = H}
+        )
+    ]).
+
+%% ============================================================================
+%% Field generators
+%% ============================================================================
+
+u8() -> integer(0, 255).
+u16() -> integer(0, 65535).
+u32() -> integer(0, 4294967295).
+u48() -> integer(0, 281474976710655).
+
+bin(Min, Max) -> ?LET(N, integer(Min, Max), binary(N)).
+ascii(Min, Max) ->
+    ?LET(N, integer(Min, Max), ?LET(L, vector(N, integer($a, $z)), list_to_binary(L))).
+
+ip4() -> {u8(), u8(), u8(), u8()}.
+ip6() -> {u16(), u16(), u16(), u16(), u16(), u16(), u16(), u16()}.
+
+dname() -> dns_prop_generator:valid_dname().
+
+%% At least one non-empty string, plus empty ones, which is the case the encoder
+%% used to drop; nothing over 255 bytes, which the encoder legitimately splits.
+charstrings() ->
+    ?LET({Head, Rest}, {bin(1, 12), list(bin(0, 12))}, [Head | Rest]).
+
+types() -> ?LET(L, list(u16()), lists:usort(L)).
+%% RFC2535§5.2 gives NXT a windowless bitmap, so only low type numbers fit
+nxt_types() -> ?LET(L, list(integer(0, 127)), lists:usort(L)).
+
+%% RFC1876§2: base * 10^exp with both in 0..9, the only exactly representable values
+loc_precision() -> ?LET({B, E}, {integer(0, 9), integer(0, 9)}, B * pow10(E)).
+loc_coord() -> integer(-2147483648, 2147483647).
+
+pow10(E) -> pow10(E, 1).
+pow10(0, Acc) -> Acc;
+pow10(E, Acc) -> pow10(E - 1, Acc * 10).
+
+%% Targets that survive uri_string:normalize/1's validity check
+uri() ->
+    ?LET(
+        {Scheme, Host, Path},
+        {oneof([<<"http">>, <<"https">>, <<"ftp">>]), ascii(1, 8), ascii(0, 8)},
+        <<Scheme/binary, "://", Host/binary, "/", Path/binary>>
+    ).
+
+%% ============================================================================
+%% Type mapping
+%% ============================================================================
+
+%% Spelled out rather than derived from the record tag, so a record generated
+%% without a matching entry fails to compile instead of being silently mistyped.
+-spec type_of(dns:rrdata()) -> dns:type().
+type_of(#dns_rrdata_a{}) -> ?DNS_TYPE_A;
+type_of(#dns_rrdata_aaaa{}) -> ?DNS_TYPE_AAAA;
+type_of(#dns_rrdata_afsdb{}) -> ?DNS_TYPE_AFSDB;
+type_of(#dns_rrdata_caa{}) -> ?DNS_TYPE_CAA;
+type_of(#dns_rrdata_cdnskey{}) -> ?DNS_TYPE_CDNSKEY;
+type_of(#dns_rrdata_cds{}) -> ?DNS_TYPE_CDS;
+type_of(#dns_rrdata_cert{}) -> ?DNS_TYPE_CERT;
+type_of(#dns_rrdata_cname{}) -> ?DNS_TYPE_CNAME;
+type_of(#dns_rrdata_csync{}) -> ?DNS_TYPE_CSYNC;
+type_of(#dns_rrdata_dhcid{}) -> ?DNS_TYPE_DHCID;
+type_of(#dns_rrdata_dlv{}) -> ?DNS_TYPE_DLV;
+type_of(#dns_rrdata_dname{}) -> ?DNS_TYPE_DNAME;
+type_of(#dns_rrdata_dnskey{}) -> ?DNS_TYPE_DNSKEY;
+type_of(#dns_rrdata_ds{}) -> ?DNS_TYPE_DS;
+type_of(#dns_rrdata_dsync{}) -> ?DNS_TYPE_DSYNC;
+type_of(#dns_rrdata_eui48{}) -> ?DNS_TYPE_EUI48;
+type_of(#dns_rrdata_eui64{}) -> ?DNS_TYPE_EUI64;
+type_of(#dns_rrdata_hinfo{}) -> ?DNS_TYPE_HINFO;
+type_of(#dns_rrdata_https{}) -> ?DNS_TYPE_HTTPS;
+type_of(#dns_rrdata_ipseckey{}) -> ?DNS_TYPE_IPSECKEY;
+type_of(#dns_rrdata_key{}) -> ?DNS_TYPE_KEY;
+type_of(#dns_rrdata_kx{}) -> ?DNS_TYPE_KX;
+type_of(#dns_rrdata_loc{}) -> ?DNS_TYPE_LOC;
+type_of(#dns_rrdata_mb{}) -> ?DNS_TYPE_MB;
+type_of(#dns_rrdata_mg{}) -> ?DNS_TYPE_MG;
+type_of(#dns_rrdata_minfo{}) -> ?DNS_TYPE_MINFO;
+type_of(#dns_rrdata_mr{}) -> ?DNS_TYPE_MR;
+type_of(#dns_rrdata_mx{}) -> ?DNS_TYPE_MX;
+type_of(#dns_rrdata_naptr{}) -> ?DNS_TYPE_NAPTR;
+type_of(#dns_rrdata_ns{}) -> ?DNS_TYPE_NS;
+type_of(#dns_rrdata_nsec{}) -> ?DNS_TYPE_NSEC;
+type_of(#dns_rrdata_nsec3{}) -> ?DNS_TYPE_NSEC3;
+type_of(#dns_rrdata_nsec3param{}) -> ?DNS_TYPE_NSEC3PARAM;
+type_of(#dns_rrdata_nxt{}) -> ?DNS_TYPE_NXT;
+type_of(#dns_rrdata_openpgpkey{}) -> ?DNS_TYPE_OPENPGPKEY;
+type_of(#dns_rrdata_ptr{}) -> ?DNS_TYPE_PTR;
+type_of(#dns_rrdata_resinfo{}) -> ?DNS_TYPE_RESINFO;
+type_of(#dns_rrdata_rp{}) -> ?DNS_TYPE_RP;
+type_of(#dns_rrdata_rrsig{}) -> ?DNS_TYPE_RRSIG;
+type_of(#dns_rrdata_rt{}) -> ?DNS_TYPE_RT;
+type_of(#dns_rrdata_smimea{}) -> ?DNS_TYPE_SMIMEA;
+type_of(#dns_rrdata_soa{}) -> ?DNS_TYPE_SOA;
+type_of(#dns_rrdata_spf{}) -> ?DNS_TYPE_SPF;
+type_of(#dns_rrdata_srv{}) -> ?DNS_TYPE_SRV;
+type_of(#dns_rrdata_sshfp{}) -> ?DNS_TYPE_SSHFP;
+type_of(#dns_rrdata_svcb{}) -> ?DNS_TYPE_SVCB;
+type_of(#dns_rrdata_tlsa{}) -> ?DNS_TYPE_TLSA;
+type_of(#dns_rrdata_tsig{}) -> ?DNS_TYPE_TSIG;
+type_of(#dns_rrdata_txt{}) -> ?DNS_TYPE_TXT;
+type_of(#dns_rrdata_uri{}) -> ?DNS_TYPE_URI;
+type_of(#dns_rrdata_wallet{}) -> ?DNS_TYPE_WALLET;
+type_of(#dns_rrdata_zonemd{}) -> ?DNS_TYPE_ZONEMD.


### PR DESCRIPTION
Six defects in the RDATA wire codec, plus the property suite that turned three of them up.

Three of these break DNSSEC, and all three by the same mechanism: `dnssec:canonical_rrdata_bin/1` builds signature input by re-encoding a decoded record, so anything the codec rewrites or mishandles on that path lands under the digest.

See commits for details.

## Behaviour changes worth a look

- **Decoding is stricter in two places**, and both reject input that previously parsed: a repeated or out-of-order bitmap window, and a LOC precision octet with a base above nine. Both are unambiguous RFC violations, and real signers produce neither.
- **`uri_decode_normalization` had to be rewritten.** It asserted the normalising behaviour as intended. It is now `uri_decode_preserves_target` and additionally asserts that canonical RDATA equals the wire form, which is the property that actually matters. Which inputs are *rejected* is unchanged, so `uri_decode_invalid_error` still passes untouched.

## Verification

`make test` green: 707 tests, xref, dialyzer, coverage 90% → 91%. All four commits compile independently. Each fix was confirmed to fail against the unfixed code and pass after — including the DSA width test, which fails at the `P`-with-leading-zero case.

erldns was built against this branch through a local rebar checkout: 309 tests pass and dialyzer is clean, identical to its baseline against the released `dns_erlang`.