### PR TITLE
Reject double OPT RRs on encode, and keep odd RSA keys opaque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `encode_rrdata/2` crashed with `badmap` on every KX record, and with it the DNSSEC canonical form (RFC 2230)
 - A repeated or out-of-order NSEC/NSEC3/CSYNC type-bitmap window decoded to a types list containing duplicates (RFC 4034 §4.1.2)
 - LOC precision octets with a base nibble above nine were accepted instead of being left opaque (RFC 1876 §2)
+- `encode_message/1,2` would emit a message carrying two OPT RRs, which the decoder rejects (RFC 6891 §6.1.1)
 
 ## v5.0.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A repeated or out-of-order NSEC/NSEC3/CSYNC type-bitmap window decoded to a types list containing duplicates (RFC 4034 §4.1.2)
 - LOC precision octets with a base nibble above nine were accepted instead of being left opaque (RFC 1876 §2)
 - `encode_message/1,2` would emit a message carrying two OPT RRs, which the decoder rejects (RFC 6891 §6.1.1)
+- A non-canonically encoded RSA DNSKEY/CDNSKEY public key changed shape when re-encoded, altering the canonical RDATA an RRSIG covers (RFC 3110 §2)
 
 ## v5.0.13
 

--- a/SUPPORTED_RFCS.md
+++ b/SUPPORTED_RFCS.md
@@ -14,6 +14,7 @@ functionality such as socket handling or query resolution.
 - **[RFC 2536](https://tools.ietf.org/html/rfc2536)**: DSA KEYs and SIGs in the Domain Name System (DNS)
 - **[RFC 2782](https://tools.ietf.org/html/rfc2782)**: A DNS RR for specifying the location of services (DNS SRV)
 - **[RFC 2845](https://tools.ietf.org/html/rfc2845)**: Secret Key Transaction Authentication for DNS (TSIG)
+- **[RFC 3110](https://tools.ietf.org/html/rfc3110)**: RSA/SHA-1 SIGs and RSA KEYs in the Domain Name System (DNS)
 - **[RFC 3403](https://tools.ietf.org/html/rfc3403)**: Dynamic Delegation Discovery System (DDDS) Part Three: The Domain Name System (DNS) Database
 - **[RFC 3596](https://tools.ietf.org/html/rfc3596)**: DNS Extensions to Support IP Version 6
 - **[RFC 3597](https://tools.ietf.org/html/rfc3597)**: Handling of Unknown DNS Resource Record (RR) Types

--- a/scripts/generate_rfc_list.escript
+++ b/scripts/generate_rfc_list.escript
@@ -33,6 +33,7 @@
         ~"Dynamic Delegation Discovery System (DDDS) Part Three: The Domain Name System (DNS) Database",
     ~"2308" => ~"Negative Caching of DNS Queries (DNS NCACHE)",
     ~"2536" => ~"DSA KEYs and SIGs in the Domain Name System (DNS)",
+    ~"3110" => ~"RSA/SHA-1 SIGs and RSA KEYs in the Domain Name System (DNS)",
     ~"3597" => ~"Handling of Unknown DNS Resource Record (RR) Types",
     ~"4025" => ~"A Method for Storing IPsec Keying Material in DNS",
     ~"4255" => ~"Using DNS to Securely Publish Secure Shell (SSH) Key Fingerprints",

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -1071,15 +1071,23 @@ decode_dnameonly(MsgBin, Bin) ->
 %% Helper function to decode RSA keys for DNSKEY and CDNSKEY records
 -spec decode_rsa_key(binary(), binary()) -> {list(), dns:uint16()}.
 decode_rsa_key(PublicKey, Bin) ->
-    Key =
-        case PublicKey of
-            <<0, Len:16, Exp:Len/unit:8, ModBin/binary>> ->
-                [Exp, binary:decode_unsigned(ModBin)];
-            <<Len:8, Exp:Len/unit:8, ModBin/binary>> ->
-                [Exp, binary:decode_unsigned(ModBin)]
-        end,
     KeyTag = bin_to_key_tag(Bin),
-    {Key, KeyTag}.
+    case rsa_fields(PublicKey) of
+        {ExpBin, ModBin} ->
+            {[binary:decode_unsigned(ExpBin), binary:decode_unsigned(ModBin)], KeyTag};
+        not_canonical ->
+            {PublicKey, KeyTag}
+    end.
+
+%% RFC3110§2: exponent length in one octet, or zero then two octets.
+%% Real keys are canonical -- an RSA modulus has its top bit set, and 65537 starts 0x01.
+-spec rsa_fields(binary()) -> {binary(), binary()} | not_canonical.
+rsa_fields(<<0, Len:16, Exp:Len/binary, Mod/binary>>) when 255 < Len -> rsa_fields(Exp, Mod);
+rsa_fields(<<Len:8, Exp:Len/binary, Mod/binary>>) -> rsa_fields(Exp, Mod);
+rsa_fields(<<_/binary>>) -> not_canonical.
+
+rsa_fields(<<E, _/binary>> = Exp, <<M, _/binary>> = Mod) when 0 < E, 0 < M -> {Exp, Mod};
+rsa_fields(_Exp, _Mod) -> not_canonical.
 
 %% Helper function to decode DSA keys for DNSKEY and CDNSKEY records
 -spec decode_dsa_key(byte(), non_neg_integer(), binary(), binary()) -> {list(), dns:uint16()}.

--- a/src/dns_encode.erl
+++ b/src/dns_encode.erl
@@ -40,6 +40,7 @@ encode(
         additional = Additional
     } = Msg
 ) ->
+    ok = assert_single_optrr(Additional),
     Head = encode_message_header(Msg),
     encode_sections(Head, #{}, [Questions, Answers, Authority, Additional]).
 
@@ -64,6 +65,7 @@ encode_append_section(Acc, CompMap, [Rec | Rest]) ->
     | {truncated, dns:message_bin(), dns:message()}
     | {truncated, dns:message_bin(), dns:tsig_mac(), dns:message()}.
 encode(#dns_message{id = MsgId, additional = Additional} = Msg, Opts) ->
+    ok = assert_single_optrr(Additional),
     EncodeFun = get_tc_mode_fun(Opts),
     MaxSize = get_max_size(Opts, Additional),
     case maps:get(tsig, Opts, undefined) of
@@ -284,6 +286,19 @@ append_optrr(Acc, [RR | Rest]) ->
     end.
 
 %% RFC6891§6.1.1: the OPT RR "MAY be placed anywhere within the additional data section",
+%% RFC6891§6.1.1: an OPT RR "MUST be the only OPT RR in that message"; the
+%% decoder rejects a second, so refuse to emit one. Stops after the first, so a
+%% section with no OPT or one OPT costs a clause or two.
+-spec assert_single_optrr(dns:additional()) -> ok.
+assert_single_optrr([#dns_optrr{} | Rest]) -> assert_no_optrr(Rest);
+assert_single_optrr([_RR | Rest]) -> assert_single_optrr(Rest);
+assert_single_optrr([]) -> ok.
+
+-spec assert_no_optrr(dns:additional()) -> ok.
+assert_no_optrr([#dns_optrr{} | _]) -> erlang:error(multiple_optrr);
+assert_no_optrr([_RR | Rest]) -> assert_no_optrr(Rest);
+assert_no_optrr([]) -> ok.
+
 -spec find_optrr(dns:additional()) -> dns:optrr() | undefined.
 find_optrr([#dns_optrr{} = OptRR | _]) -> OptRR;
 find_optrr([_ | Rest]) -> find_optrr(Rest);

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -65,6 +65,7 @@ groups() ->
             bad_optrr_too_large,
             optrr_must_be_root_named_and_singular,
             optrr_honoured_anywhere_in_additional,
+            encode_rejects_second_optrr,
             dnskey_dsa_alg_short_rdata_reencodes,
             dnskey_dsa_field_width_preserved,
             uri_decode_preserves_target,
@@ -1505,6 +1506,68 @@ dnskey_dsa_alg_short_rdata_reencodes(_) ->
         #dns_rrdata_dnskey{alg = ?DNS_ALG_DSA, public_key = [_, _, _, _]},
         dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_DNSKEY, DsaWire)
     ).
+
+%% RFC6891§6.1.1: an OPT RR "MUST be the only OPT RR in that message". The
+%% decoder rejects a second one, but the encoder would happily emit two, so a
+%% caller could build a response no compliant peer -- nor this library -- accepts.
+encode_rejects_second_optrr(_) ->
+    ARecord = #dns_rr{
+        name = <<"ns.example.com">>,
+        type = ?DNS_TYPE_A,
+        class = ?DNS_CLASS_IN,
+        ttl = 300,
+        data = #dns_rrdata_a{ip = {192, 0, 2, 1}}
+    },
+    OptRR = #dns_optrr{udp_payload_size = 1232},
+    Msg = fun(Additional) ->
+        #dns_message{
+            id = 1,
+            qc = 1,
+            questions = [
+                #dns_query{name = <<"example.com">>, type = ?DNS_TYPE_A, class = ?DNS_CLASS_IN}
+            ],
+            adc = length(Additional),
+            additional = Additional
+        }
+    end,
+    %% Every encoding path refuses, not just the default one
+    Opts = [#{}, #{tc_mode => axfr}, #{tc_mode => llq_event}, #{max_size => 4096}],
+    [
+        begin
+            ?assertError(multiple_optrr, dns:encode_message(Msg(Additional)), Label),
+            [
+                ?assertError(multiple_optrr, dns:encode_message(Msg(Additional), O), {Label, O})
+             || O <- Opts
+            ]
+        end
+     || {Label, Additional} <- [
+            {"[OPT, OPT]", [OptRR, OptRR]},
+            {"[OPT, A, OPT]", [OptRR, ARecord, OptRR]},
+            {"[A, OPT, OPT]", [ARecord, OptRR, OptRR]}
+        ]
+    ],
+    %% One OPT, or none, still encodes on every path
+    [
+        begin
+            ?assert(is_binary(dns:encode_message(Msg(Additional))), Label),
+            %% every path yields either a message or a truncated one, never a raise
+            [
+                begin
+                    Encoded = dns:encode_message(Msg(Additional), O),
+                    ?assert(
+                        is_binary(Encoded) orelse truncated =:= element(1, Encoded), {Label, O}
+                    )
+                end
+             || O <- Opts
+            ]
+        end
+     || {Label, Additional} <- [
+            {"[]", []},
+            {"[OPT]", [OptRR]},
+            {"[A, OPT]", [ARecord, OptRR]},
+            {"[A, A]", [ARecord, ARecord]}
+        ]
+    ].
 
 %% RFC6891§6.1.1: the OPT RR "MAY be placed anywhere within the additional data
 %% section". The encoder matched it only at the head, so an OPT sitting anywhere

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -68,6 +68,7 @@ groups() ->
             encode_rejects_second_optrr,
             dnskey_dsa_alg_short_rdata_reencodes,
             dnskey_dsa_field_width_preserved,
+            dnskey_rsa_non_canonical_kept_opaque,
             uri_decode_preserves_target,
             uri_decode_invalid_error,
             decode_encode_rrdata_wire_samples,
@@ -1379,6 +1380,56 @@ optrr_must_be_root_named_and_singular(_) ->
         #dns_message{additional = [#dns_optrr{}, #dns_rr{type = ?DNS_TYPE_A}]},
         dns:decode_message(<<(Header(2))/binary, RootOpt/binary, PlainRR/binary>>)
     ).
+
+%% RFC3110§2 encodes an RSA key as an exponent length, the exponent, then the
+%% modulus. Decoding turns those into the integer pair [E, M], which cannot hold a
+%% zero-length field, a leading zero, or the choice of exponent-length form -- and
+%% encoding strips leading zeros and always picks the short form below 256. Such a
+%% key is therefore kept opaque, so it re-encodes byte for byte; otherwise a
+%% DNSKEY would change shape on the way through, and with it the canonical RDATA
+%% an RRSIG covers.
+dnskey_rsa_non_canonical_kept_opaque(_) ->
+    Modulus = <<255, (binary:copy(<<16#AB>>, 127))/binary>>,
+    Canonical = [
+        %% exponent 65537 in the one-octet length form, modulus with its top bit set
+        {"e=65537, short form", <<256:16, 3:8, (?DNS_ALG_RSASHA256):8, 3, 1, 0, 1, Modulus/binary>>}
+    ],
+    NonCanonical = [
+        {"all-zero key", <<0:16, 0:8, (?DNS_ALG_RSASHA1):8, 0:(24 * 8)>>},
+        {"zero-length exponent", <<0:16, 3:8, (?DNS_ALG_RSASHA1):8, 0, 0, 0, 1, 2, 3>>},
+        {"leading-zero modulus", <<0:16, 3:8, (?DNS_ALG_RSASHA1):8, 1, 3, 0, 255, 255, 255>>},
+        {"leading-zero exponent", <<0:16, 3:8, (?DNS_ALG_RSASHA1):8, 2, 0, 3, 255, 255, 255>>},
+        %% the two-octet length form used for an exponent that fits one octet
+        {"long form, short exponent",
+            <<256:16, 3:8, (?DNS_ALG_RSASHA256):8, 0, 0, 3, 1, 0, 1, Modulus/binary>>}
+    ],
+    %% A canonically encoded key is parsed into [E, M] ...
+    [
+        begin
+            Decoded = dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_DNSKEY, Rdata),
+            ?assertMatch(#dns_rrdata_dnskey{public_key = [_, _]}, Decoded, Label),
+            ?assertEqual(Rdata, dns_encode:encode_rrdata(?DNS_CLASS_IN, Decoded), Label)
+        end
+     || {Label, Rdata} <- Canonical
+    ],
+    %% ... anything else stays a binary, and either way the bytes are reproduced
+    [
+        begin
+            Decoded = dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_DNSKEY, Rdata),
+            #dns_rrdata_dnskey{public_key = PublicKey} = Decoded,
+            ?assert(is_binary(PublicKey), Label),
+            ?assertEqual(Rdata, dns_encode:encode_rrdata(?DNS_CLASS_IN, Decoded), Label)
+        end
+     || {Label, Rdata} <- NonCanonical
+    ],
+    %% CDNSKEY shares the decoder, and so the behaviour
+    [
+        begin
+            Decoded = dns_decode:decode_rrdata(<<>>, ?DNS_CLASS_IN, ?DNS_TYPE_CDNSKEY, Rdata),
+            ?assertEqual(Rdata, dns_encode:encode_rrdata(?DNS_CLASS_IN, Decoded), Label)
+        end
+     || {Label, Rdata} <- Canonical ++ NonCanonical
+    ].
 
 %% RFC2536§2 gives P, G and Y one shared width S = 64 + 8T, T in 0..8, with T on
 %% the wire but absent from the record, so encoding has to derive it. It derived


### PR DESCRIPTION
Two wire-format fixes, see commits for details.