### PR TITLE
Decode rfc2136 UPDATE, and refuse to serve it with NOTIMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v5.0.15
+
+### Fixed
+
+- `decode_message/1` now decodes rfc2136 UPDATE messages, while `decode_query/1` does not anymore as it shouldn't have, returning `notimp`.
+
 ## v5.0.14
 
 ### Updated

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -89,24 +89,14 @@ decode_query(
         %% traffic) must be rejected rather than fall through the case and crash.
         {0, 0, ?DNS_OPCODE_NOTIFY, _, _, _, _} ->
             {formerr, undefined, MsgBin};
-        %% UPDATE (opcode 5) - rfc2136
-        %% Expected: QR=0, TC=0, QC=1 (ZONE section), ANC>=0 (PREREQ section),
-        %%   AUC>=0 (UPDATE section)
-        %% rfc2136 §2.3: UPDATE has ZONE section (question), PREREQ section (answer),
-        %%   UPDATE section (authority).
-        %% We allow any QC/ANC/AUC here as rfc2136 defines these sections for UPDATE.
-        %%   However, typical implementations expect QC=1 (ZONE section).
-        {0, 0, ?DNS_OPCODE_UPDATE, _, _, _, _} ->
-            Msg0 = create_message_from_header(
-                Id, QR, OC, AA, TC, RD, RA, AD, CD, RC, QC, ANC, AUC, ADC
-            ),
-            decode_body(MsgBin, Rest0, Msg0);
         %% IQUERY (opcode 1) - RFC 1035 (obsolete per rfc3425)
         %% STATUS (opcode 2) - RFC 1035 (Not commonly supported)
+        %% UPDATE (opcode 5) - rfc2136 (we don't serve it; §3.1 allows NOTIMP)
         %% DSO (opcode 6) - rfc8490 (we don't support it)
         {0, 0, _, _, _, _, _} when
             ?DNS_OPCODE_IQUERY =:= OC orelse
                 ?DNS_OPCODE_STATUS =:= OC orelse
+                ?DNS_OPCODE_UPDATE =:= OC orelse
                 ?DNS_OPCODE_DSO =:= OC
         ->
             create_notimp_message(MsgBin, Id, OC, RD, CD, QC, Rest0);
@@ -499,6 +489,12 @@ decode_rrdata(MsgBin, Class, Type) ->
     decode_rrdata(MsgBin, Class, Type, MsgBin).
 
 -spec decode_rrdata(dns:message_bin(), dns:uint16(), dns:uint16(), binary()) -> dns:rrdata().
+%% rfc2136 §2.4, §2.5: in an UPDATE's prerequisite and update sections an RR with CLASS ANY or
+%% NONE carries no RDATA, so RDLENGTH=0 is the intended encoding rather than a truncated record.
+decode_rrdata(_MsgBin, Class, _Type, <<>>) when
+    ?DNS_CLASS_ANY =:= Class orelse ?DNS_CLASS_NONE =:= Class
+->
+    <<>>;
 decode_rrdata(_MsgBin, _Class, Type, <<>>) ->
     empty_rrdata(Type);
 decode_rrdata(_MsgBin, Class, ?DNS_TYPE_A, <<A, B, C, D>>) when ?CLASS_IS_IN(Class) ->

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -35,7 +35,8 @@ groups() ->
             message_empty,
             message_query,
             message_other,
-            truncated_answer_rr_header
+            truncated_answer_rr_header,
+            decode_message_rfc2136_update
         ]},
         {message_encoding, [parallel], [
             encode_message_max_size,
@@ -134,7 +135,7 @@ groups() ->
             decode_query_qdcount_invalid,
             decode_query_notify_allowed,
             decode_query_notify_invalid_counts,
-            decode_query_update_allowed,
+            decode_query_update_notimp,
             decode_query_too_short,
             decode_query_iquery_notimp,
             decode_query_status_notimp,
@@ -2409,28 +2410,106 @@ decode_query_notify_invalid_counts(_) ->
     ModifiedBin = <<ModifiedHeader/binary, Rest/binary>>,
     ?assertMatch({formerr, undefined, _}, dns:decode_query(ModifiedBin)).
 
-decode_query_update_allowed(_) ->
-    %% UPDATE (opcode 5) should be allowed even with Answer/Authority records
-    QName = <<"example.com">>,
-    Query = #dns_query{name = QName, type = ?DNS_TYPE_SOA},
-    Answer = #dns_rr{
-        name = QName,
-        type = ?DNS_TYPE_A,
-        ttl = 3600,
-        data = #dns_rrdata_a{ip = {127, 0, 0, 1}}
-    },
-    Msg = #dns_message{
-        qc = 1,
-        anc = 1,
-        auc = 1,
-        oc = 5,
-        questions = [Query],
-        answers = [Answer],
-        authority = [Answer]
-    },
-    Encoded = dns:encode_message(Msg),
-    Decoded = dns:decode_query(Encoded),
-    ?assertMatch(#dns_message{oc = 5, anc = 1, auc = 1}, Decoded).
+decode_query_update_notimp(_) ->
+    %% UPDATE (opcode 5) is not a query, so `decode_query/1` refuses to serve it and returns
+    %% NOTIMP, which rfc2136 §3.1 permits for a server that does not implement UPDATE. Parsing
+    %% the message itself is `decode_message/1`'s job — see decode_message_rfc2136_update/1.
+    Bin = rfc2136_update_wire(),
+    Result = dns:decode_query(Bin),
+    ?assertMatch(
+        {notimp, #dns_message{oc = ?DNS_OPCODE_UPDATE, rc = ?DNS_RCODE_NOTIMP, qr = true}, _},
+        Result
+    ),
+    {notimp, NotImpMsg, _} = Result,
+    ?assertEqual(0, NotImpMsg#dns_message.anc),
+    ?assertEqual(0, NotImpMsg#dns_message.auc),
+    ?assertEqual(0, NotImpMsg#dns_message.adc),
+    %% The ZONE section (rfc2136 §2.3) is preserved so a responder can log/route on it
+    ?assertEqual(1, NotImpMsg#dns_message.qc),
+    ?assertMatch(
+        [#dns_query{name = <<"example.com">>, class = ?DNS_CLASS_IN, type = ?DNS_TYPE_SOA}],
+        NotImpMsg#dns_message.questions
+    ).
+
+decode_message_rfc2136_update(_) ->
+    %% Shaped after the dynamic-update datagrams a Windows DHCP client sends when registering
+    %% itself. rfc2136 §2.4/§2.5 encode prerequisites and RRset deletes with RDLENGTH=0, which
+    %% rfc1035 §3.2.1 would reject for these types; `decode_message/1` must accept them so that
+    %% a server implementing UPDATE can act on them.
+    Msg = dns:decode_message(rfc2136_update_wire()),
+    ?assertMatch(#dns_message{oc = ?DNS_OPCODE_UPDATE, qc = 1, anc = 1, auc = 6}, Msg),
+    Owner = <<"host1.example.com">>,
+    %% §2.4.5 "RRset does not exist" prerequisite: CLASS=NONE, RDLENGTH=0
+    ?assertMatch(
+        [#dns_rr{name = Owner, class = ?DNS_CLASS_NONE, type = ?DNS_TYPE_CNAME, data = <<>>}],
+        Msg#dns_message.answers
+    ),
+    ?assertMatch(
+        [
+            %% §2.5.2 "Delete an RRset": CLASS=ANY, RDLENGTH=0
+            #dns_rr{name = Owner, class = ?DNS_CLASS_ANY, type = ?DNS_TYPE_AAAA, data = <<>>},
+            #dns_rr{name = Owner, class = ?DNS_CLASS_ANY, type = ?DNS_TYPE_A, data = <<>>},
+            %% §2.5.1 "Add to an RRset": CLASS=IN, RDLENGTH>0
+            #dns_rr{
+                name = Owner,
+                class = ?DNS_CLASS_IN,
+                type = ?DNS_TYPE_AAAA,
+                ttl = 1200,
+                data = #dns_rrdata_aaaa{ip = {16#2001, 16#0db8, 0, 0, 0, 0, 0, 1}}
+            },
+            #dns_rr{
+                name = Owner,
+                class = ?DNS_CLASS_IN,
+                type = ?DNS_TYPE_A,
+                ttl = 1200,
+                data = #dns_rrdata_a{ip = {192, 0, 2, 1}}
+            },
+            #dns_rr{
+                name = Owner,
+                class = ?DNS_CLASS_IN,
+                type = ?DNS_TYPE_AAAA,
+                ttl = 1200,
+                data = #dns_rrdata_aaaa{ip = {16#2001, 16#0db8, 0, 0, 0, 0, 0, 2}}
+            },
+            #dns_rr{
+                name = Owner,
+                class = ?DNS_CLASS_IN,
+                type = ?DNS_TYPE_A,
+                ttl = 1200,
+                data = #dns_rrdata_a{ip = {192, 0, 2, 2}}
+            }
+        ],
+        Msg#dns_message.authority
+    ),
+    %% The zero-RDLENGTH records survive a re-encode
+    ?assertMatch(#dns_message{anc = 1, auc = 6}, dns:decode_message(dns:encode_message(Msg))).
+
+%% An rfc2136 UPDATE on the wire: ZONE example.com/IN/SOA, one §2.4.5 prerequisite and six
+%% update records against host1.example.com. Addresses are documentation ranges (rfc5737,
+%% rfc3849). The owner name is written out in full at offset 29 — just past the 12-byte header
+%% and the 17-byte ZONE section — so every later record refers back to it by compression pointer.
+rfc2136_update_wire() ->
+    Owner = <<5, "host1", 7, "example", 3, "com", 0>>,
+    Ptr = <<3:2, 29:14>>,
+    Zone = <<7, "example", 3, "com", 0, ?DNS_TYPE_SOA:16, ?DNS_CLASS_IN:16>>,
+    %% §2.4.5 "RRset does not exist": CLASS=NONE, RDLENGTH=0
+    Prereq = <<Owner/binary, ?DNS_TYPE_CNAME:16, ?DNS_CLASS_NONE:16, 0:32, 0:16>>,
+    %% §2.5.2 "Delete an RRset": CLASS=ANY, RDLENGTH=0
+    DelAaaa = <<Ptr/binary, ?DNS_TYPE_AAAA:16, ?DNS_CLASS_ANY:16, 0:32, 0:16>>,
+    DelA = <<Ptr/binary, ?DNS_TYPE_A:16, ?DNS_CLASS_ANY:16, 0:32, 0:16>>,
+    %% §2.5.1 "Add to an RRset": CLASS=IN, RDLENGTH>0
+    AddAaaa = fun(Low) ->
+        <<Ptr/binary, ?DNS_TYPE_AAAA:16, ?DNS_CLASS_IN:16, 1200:32, 16:16, 16#2001:16, 16#0db8:16,
+            0:16, 0:16, 0:16, 0:16, 0:16, Low:16>>
+    end,
+    AddA = fun(Low) ->
+        <<Ptr/binary, ?DNS_TYPE_A:16, ?DNS_CLASS_IN:16, 1200:32, 4:16, 192, 0, 2, Low>>
+    end,
+    Body =
+        <<Prereq/binary, DelAaaa/binary, DelA/binary, (AddAaaa(1))/binary, (AddA(1))/binary,
+            (AddAaaa(2))/binary, (AddA(2))/binary>>,
+    <<16#2a1b:16, 0:1, ?DNS_OPCODE_UPDATE:4, 0:1, 0:1, 0:1, 0:1, 0:1, 0:1, 0:1, 0:4, 1:16, 1:16,
+        6:16, 0:16, Zone/binary, Body/binary>>.
 
 decode_query_too_short(_) ->
     %% Binary shorter than 12 bytes should be rejected


### PR DESCRIPTION
a4f90e2 made empty RDATA an error for every type in requires_rrdata/1, on the grounds that RFC 1035 §3.2.1 leaves no room for a known type to carry zero octets. rfc2136 is the exception: §2.4 prerequisites and the §2.5.2/§2.5.3 RRset deletes all encode a concrete RRTYPE with RDLENGTH = 0, because such an RR names an RRset rather than asserting one. Windows DHCP clients emit these continuously at whatever nameserver DHCP hands them, so an authoritative server sees a steady stream.

The result was formerr on traffic that is not malformed. erldns logs that at error and sends nothing back, so the client retries on a timer and one misconfigured LAN produces an unbounded stream of events. Built at a4f90e2^, the same datagrams decode clean, prerequisites and all -- this is a v5.0.14 regression, not a long-standing gap.

Gate the empty-RDATA clause on CLASS instead of dropping it: ANY and NONE are exactly the rfc2136 delete and prerequisite encodings, and neither can appear in query or response traffic. CLASS IN with RDLENGTH = 0 still raises, so a zero-length A record is caught as before and a4f90e2's reasoning is left intact -- only narrowed to the records it did not consider.

Decoding an UPDATE is not the same as agreeing to serve one, so decode_query/1 now hands opcode 5 to create_notimp_message/7 alongside IQUERY, STATUS and DSO, which rfc2136 §3.1 permits from a server that does not implement UPDATE. This is a breaking change for a caller implementing rfc2136 on top of decode_query/1; that caller wants decode_message/1, which parses the message in full. It also closes a silent failure: erldns has no opcode dispatch at all, so a decoded UPDATE would fall through the ordinary pipeline and be answered as a plain SOA query for the zone -- NOERROR, telling the client its registration succeeded. Returning notimp is the difference between a wrong answer and an honest one.

The split mirrors PowerDNS, which parses UPDATE in MOADNSParser -- skipping rdata for prerequisite records, as here -- and keeps the NotImp decision in its opcode handler table. decode_query/1 is where that decision lives here, since it already carries the same policy for four other opcodes.

The regression test builds its datagram from documentation ranges (rfc5737, rfc3849) rather than captured traffic.