### PR TITLE
Decline zone transfers in decode_query/1 (rfc1995, rfc5936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v5.0.16
+
+### Fixed
+
+- `decode_query/1` no longer rejects rfc1995 IXFR queries as `formerr` but as `notimp`.
+
 ## v5.0.15
 
 ### Fixed

--- a/src/dns_decode.erl
+++ b/src/dns_decode.erl
@@ -59,15 +59,19 @@ decode_query(
     %% - OC bit check: each opcode has its own sensible combination of section counts
     %% - RCODE in queries is typically 0 (NOERROR) but most servers don't enforce this validation
     case {QR, TC, OC, QC, ANC, AUC, ADC} of
-        %% RFC 1035: Standard queries must have exactly 1 question, no answers, no authority.
+        %% RFC 1035: Standard queries must have exactly 1 question and no answers.
         %% RFC 9619: A DNS message with OPCODE = 0 MUST NOT include a QDCOUNT parameter whose value
         %% is greater than 1. It follows that the Question section of a DNS message with OPCODE = 0
         %% MUST NOT contain more than one question.
-        {0, 0, ?DNS_OPCODE_QUERY, 1, 0, 0, _} ->
+        %% rfc1995 §3: an IXFR query carries the client's current SOA in the authority section, so
+        %% one authority record is legitimate here. The qtype lives in the question section, which
+        %% this header guard has not read yet, so the bound is on the count rather than on IXFR
+        %% specifically -- one record is bounded work, which is all the guard is defending.
+        {0, 0, ?DNS_OPCODE_QUERY, 1, 0, AUC, _} when AUC =< 1 ->
             Msg0 = create_message_from_header(
                 Id, QR, OC, AA, TC, RD, RA, AD, CD, RC, QC, ANC, AUC, ADC
             ),
-            decode_body(MsgBin, Rest0, Msg0);
+            zone_transfer_notimp(decode_body(MsgBin, Rest0, Msg0));
         %% RFC 7873: Cookie-only queries may have QDCOUNT=0 when an OPT record with a COOKIE option
         %% is present in the additional section.
         {0, 0, ?DNS_OPCODE_QUERY, 0, 0, 0, ADC} when ADC > 0 ->
@@ -120,6 +124,43 @@ decode_query(
     end;
 decode_query(MsgBin) ->
     {formerr, undefined, MsgBin}.
+
+%% rfc5936 AXFR and rfc1995 IXFR are zone transfers, not queries: the response is a stream of
+%% messages over a held TCP connection, which a caller that gets one message back cannot produce.
+%% rfc1035 §4.1.1 defines NOTIMP as "the name server does not support the requested kind of query",
+%% which is exactly the case here. A server that does implement transfers decodes with `decode/1`
+%% and drives its own transfer loop, as it must anyway.
+%%
+%% This runs on the decoded message rather than ahead of it: the qtype lives in the question
+%% section, and reading it before `decode_body/3` would parse the questions twice on every query.
+-spec zone_transfer_notimp(Result) -> Result when
+    Result :: dns:message() | {dns:decode_error(), dns:message() | undefined, binary()}.
+zone_transfer_notimp(#dns_message{questions = [#dns_query{type = ?DNS_TYPE_AXFR}]} = Msg) ->
+    {notimp, notimp_from_query(Msg), <<>>};
+zone_transfer_notimp(#dns_message{questions = [#dns_query{type = ?DNS_TYPE_IXFR}]} = Msg) ->
+    {notimp, notimp_from_query(Msg), <<>>};
+zone_transfer_notimp(Result) ->
+    Result.
+
+%% Same shape as `create_notimp_message/7`: id, opcode, rd and cd carry over, every section is
+%% dropped -- an IXFR query arrives with the client's SOA in its authority section (rfc1995 §3),
+%% which must not be echoed back.
+-spec notimp_from_query(dns:message()) -> dns:message().
+notimp_from_query(#dns_message{} = Msg) ->
+    Msg#dns_message{
+        qr = true,
+        aa = false,
+        tc = false,
+        ra = false,
+        ad = false,
+        rc = ?DNS_RCODE_NOTIMP,
+        anc = 0,
+        answers = [],
+        auc = 0,
+        authority = [],
+        adc = 0,
+        additional = []
+    }.
 
 %% Helper function to create a minimal message struct for NOTIMP response
 %% Returns {notimp, Message, Binary} where Message contains fields needed

--- a/test/dns_SUITE.erl
+++ b/test/dns_SUITE.erl
@@ -132,6 +132,7 @@ groups() ->
             decode_query_tc_bit_rejected,
             decode_query_ancount_rejected,
             decode_query_nscount_rejected,
+            decode_query_zone_transfer_notimp,
             decode_query_qdcount_invalid,
             decode_query_notify_allowed,
             decode_query_notify_invalid_counts,
@@ -2336,19 +2337,102 @@ decode_query_ancount_rejected(_) ->
     ?assertMatch({formerr, undefined, _}, dns:decode_query(ModifiedBin)).
 
 decode_query_nscount_rejected(_) ->
-    %% Query with NSCount=1 should be rejected
+    %% Query with NSCount>1 should be rejected. NSCount=1 is allowed through the header guard for
+    %% rfc1995 IXFR -- see decode_query_zone_transfer_notimp/1.
     QName = <<"example.com">>,
     Query = #dns_query{name = QName, type = ?DNS_TYPE_A},
     Msg = #dns_message{qc = 1, questions = [Query]},
     Encoded = dns:encode_message(Msg),
-    %% Modify header to set NSCount (AUC)=1
+    %% Modify header to set NSCount (AUC)=2
     <<Id:16, QR:1, OC:4, AA:1, TC:1, RD:1, RA:1, Z:1, AD:1, CD:1, RC:4, QC:16, ANC:16, _AUC:16,
         ADC:16, Rest/binary>> = Encoded,
     ModifiedHeader =
-        <<Id:16, QR:1, OC:4, AA:1, TC:1, RD:1, RA:1, Z:1, AD:1, CD:1, RC:4, QC:16, ANC:16, 1:16,
+        <<Id:16, QR:1, OC:4, AA:1, TC:1, RD:1, RA:1, Z:1, AD:1, CD:1, RC:4, QC:16, ANC:16, 2:16,
             ADC:16>>,
     ModifiedBin = <<ModifiedHeader/binary, Rest/binary>>,
     ?assertMatch({formerr, undefined, _}, dns:decode_query(ModifiedBin)).
+
+decode_query_zone_transfer_notimp(_) ->
+    %% A zone transfer is answered as a stream of messages, which a caller holding one decoded
+    %% message cannot produce, so decode_query/1 declines both rfc5936 AXFR and rfc1995 IXFR.
+    %% Reaching that answer for IXFR also exercises the header guard: rfc1995 §3 puts the client's
+    %% current SOA in the authority section, and NSCOUNT=1 was rejected as formerr before the qtype
+    %% could be read at all.
+    QName = <<"example.com">>,
+    Ixfr = #dns_query{name = QName, class = ?DNS_CLASS_IN, type = ?DNS_TYPE_IXFR},
+    Soa = #dns_rr{
+        name = QName,
+        class = ?DNS_CLASS_IN,
+        type = ?DNS_TYPE_SOA,
+        ttl = 0,
+        data = #dns_rrdata_soa{
+            mname = <<"ns1.example.com">>,
+            rname = <<"hostmaster.example.com">>,
+            serial = 2026072701,
+            refresh = 3600,
+            retry = 600,
+            expire = 604800,
+            minimum = 300
+        }
+    },
+    Msg = #dns_message{qc = 1, auc = 1, questions = [Ixfr], authority = [Soa]},
+    Result = dns:decode_query(dns:encode_message(Msg)),
+    ?assertMatch(
+        {notimp, #dns_message{oc = ?DNS_OPCODE_QUERY, rc = ?DNS_RCODE_NOTIMP, qr = true}, _},
+        Result
+    ),
+    {notimp, NotImpMsg, _} = Result,
+    %% The question is kept so a responder can log or route on it, every section is dropped -- the
+    %% client's own SOA must not come back at it, and the counts have to fall with the lists since
+    %% the encoder reads section lengths from the message fields.
+    ?assertEqual(1, NotImpMsg#dns_message.qc),
+    ?assertMatch(
+        [#dns_query{name = QName, type = ?DNS_TYPE_IXFR}], NotImpMsg#dns_message.questions
+    ),
+    ?assertEqual({0, [], 0, [], 0, []}, {
+        NotImpMsg#dns_message.anc,
+        NotImpMsg#dns_message.answers,
+        NotImpMsg#dns_message.auc,
+        NotImpMsg#dns_message.authority,
+        NotImpMsg#dns_message.adc,
+        NotImpMsg#dns_message.additional
+    }),
+    %% A secondary with no copy of the zone sends an all-zero SOA and an EDNS COOKIE alongside
+    Empty = Soa#dns_rr{
+        data = #dns_rrdata_soa{
+            mname = <<>>,
+            rname = <<>>,
+            serial = 0,
+            refresh = 0,
+            retry = 0,
+            expire = 0,
+            minimum = 0
+        }
+    },
+    Opt = #dns_optrr{
+        udp_payload_size = 1232,
+        dnssec = false,
+        data = [#dns_opt_cookie{client = <<16#9284d0b727d153ad:64>>}]
+    },
+    Msg2 = #dns_message{
+        qc = 1,
+        auc = 1,
+        adc = 1,
+        questions = [Ixfr],
+        authority = [Empty],
+        additional = [Opt]
+    },
+    ?assertMatch(
+        {notimp, #dns_message{rc = ?DNS_RCODE_NOTIMP}, _},
+        dns:decode_query(dns:encode_message(Msg2))
+    ),
+    %% AXFR carries no authority record, and is declined just the same
+    Axfr = #dns_query{name = QName, class = ?DNS_CLASS_IN, type = ?DNS_TYPE_AXFR},
+    Msg3 = #dns_message{qc = 1, questions = [Axfr]},
+    ?assertMatch(
+        {notimp, #dns_message{rc = ?DNS_RCODE_NOTIMP, qr = true}, _},
+        dns:decode_query(dns:encode_message(Msg3))
+    ).
 
 decode_query_qdcount_invalid(_) ->
     %% Query with QDCount=2 should be rejected


### PR DESCRIPTION
Two faults, one shape. The opcode 0 header guard from #101 required NSCOUNT = 0, but rfc1995 §3 has an IXFR client state the serial it holds by putting that SOA in the authority section, so every conformant IXFR query was rejected as formerr; erldns drops what it cannot decode without replying, so a secondary retried on a timer and never learned why. The exemption was in #101's own survey, under miekg/dns: "Allows at most 1 RR in Answer/Authority sections (for NOTIFY/IXFR)". NOTIFY got its clause.

Admitting the record is not enough, because nothing downstream knows what a transfer is. Driving the erldns pipeline with a decoded IXFR gives NOERROR, aa=true, an empty answer and the zone's SOA in authority: no record carries type 251, so it resolves to NODATA like any other qtype that matches nothing. That is worse than the formerr it replaces. rfc1995 §4 gives a lone SOA and nothing else the meaning "your copy is current", and this reply is one SOA away from that, so a lenient secondary can read it as confirmation that it is in sync with a zone it has never once transferred. Silence at least fails loudly.

So decline them here, as the opcodes above already are. rfc1035 §4.1.1 defines NOTIMP as "the name server does not support the requested kind of query", which is the literal truth: a transfer is answered as a stream of messages over a held connection, and a caller that gets one decoded message back cannot produce that. A server implementing transfers decodes with decode_message/1 and runs its own loop, as it must regardless.

The check reads the decoded message rather than gating ahead of it. The qtype lives in the question section, so testing it before decode_body/3 would parse the questions twice on every query to catch a rare one; two clauses on the way out cost the same and only on the way out. AXFR needs no authority record and never tripped the guard, but resolved to the same NODATA, so it is declined on the same footing.

Sections are dropped rather than passed through, counts with them -- the encoder takes section lengths from the message fields, and the client's own SOA must not come back at it.