### PR TITLE
Stop gen_nsec crashing on FQDN and relative spellings of a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## v5.0.17
+
+### Fixed
+
+- `gen_nsec/1,3,4` no longer crashes when a zone carries one name spelled both as an FQDN and relatively (`example.com` and `example.com.`).
+
 ## v5.0.16
 
 ### Fixed

--- a/src/dnssec.erl
+++ b/src/dnssec.erl
@@ -754,18 +754,7 @@ name_order(X, X) ->
 name_order(#dns_rr{name = X}, #dns_rr{name = X}) ->
     true;
 name_order(#dns_rr{name = A}, #dns_rr{name = B}) ->
-    LabelsA = lists:reverse(dns_domain:split(A)),
-    LabelsB = lists:reverse(dns_domain:split(B)),
-    name_order_labels(LabelsA, LabelsB).
-
-name_order_labels([X | A], [X | B]) ->
-    name_order_labels(A, B);
-name_order_labels([], [_ | _]) ->
-    true;
-name_order_labels([_ | _], []) ->
-    false;
-name_order_labels([X | _], [Y | _]) ->
-    X < Y.
+    lists:reverse(dns_domain:split(A)) =< lists:reverse(dns_domain:split(B)).
 
 -spec count_labels([binary()]) -> non_neg_integer().
 count_labels([~"*" | Labels]) ->

--- a/test/dnssec_SUITE.erl
+++ b/test/dnssec_SUITE.erl
@@ -39,6 +39,7 @@ groups() ->
             gen_nsec3_badarg,
             gen_nsec3_validation,
             gen_nsec_name_order,
+            gen_nsec_name_order_fqdn_and_relative,
             pubkey_gen,
             verify_rrset,
             verify_rrsig_expiry,
@@ -203,6 +204,27 @@ gen_nsec_name_order(_Config) ->
     ?assertEqual(3, length(Generated)),
     NSECs = [RR || #dns_rr{type = ?DNS_TYPE_NSEC} = RR <- Generated],
     ?assertEqual(3, length(NSECs)).
+
+%% One name spelled both as an FQDN and relatively is two distinct binaries that split to the same
+%% labels, so it slips past name_order/2's equality clauses and into the label comparison.
+gen_nsec_name_order_fqdn_and_relative(_Config) ->
+    RRs = [
+        #dns_rr{
+            name = ~"a.example",
+            type = ?DNS_TYPE_A,
+            class = ?DNS_CLASS_IN,
+            ttl = 3600,
+            data = #dns_rrdata_a{ip = {1, 1, 1, 1}}
+        },
+        #dns_rr{
+            name = ~"a.example.",
+            type = ?DNS_TYPE_TXT,
+            class = ?DNS_CLASS_IN,
+            ttl = 3600,
+            data = #dns_rrdata_txt{txt = [~"v=1"]}
+        }
+    ],
+    ?assertEqual(2, length(dnssec:gen_nsec(~"example", RRs, 3600))).
 
 %% Simulates wire encoding/decoding to ensure the 'data' field
 %% matches the format expected by the test comparison.


### PR DESCRIPTION
name_order_labels/2 had no clause for two exhausted label lists. Its first clause consumed equal heads and recursed, its other three each required at least one of the two lists to be non-empty, so a pair that ran out together fell through to a function_clause.

That pair is reachable: "example.com" and "example.com." are distinct binaries, so they pass name_order/2's two equality clauses untouched, but dns_domain:split/1 maps both to the same labels. A zone carrying one name in both spellings crashed gen_nsec/1,3,4.

Canonical DNS name order (RFC 4034 6.1) is Erlang term order over the labels reversed: lists compare element by element, and binaries octet by octet with the shorter of two prefixes first, which is how labels sort and how a parent sorts before its children. Comparing the reversed label lists directly replaces the four clauses and gives the exhausted pair an answer. Checked against the old function over 200k random label lists drawn from prefixes, empty labels, 0x00 and 0xff: no divergence.

=< rather than <, because lists:sort/2 wants a "less than or equal" comparator and because equal label lists must compare true.

Ordering is unchanged for zones without duplicate spellings. Tested with a new gen_nsec_name_order_fqdn_and_relative case, plus ct (712 passing), fmt, lint, xref and dialyzer.